### PR TITLE
Ks retrofit dropdowns v4

### DIFF
--- a/addon/components/rui-dropdown-menu/component.js
+++ b/addon/components/rui-dropdown-menu/component.js
@@ -3,7 +3,7 @@ import layout from './template';
 
 export default Ember.Component.extend({
   layout: layout,
-  tagName: 'ul',
+  tagName: 'div',
   classNames: 'dropdown-menu',
   classNameBindings: 'alignComputed',
   attributeBindings: ['aria-labelledby'],

--- a/addon/components/rui-dropdown-trigger/component.js
+++ b/addon/components/rui-dropdown-trigger/component.js
@@ -4,13 +4,13 @@ import layout from './template';
 export default Ember.Component.extend({
   layout: layout,
   tagName: 'button',
-  type: 'button',
   classNames: ['dropdown-toggle'],
   classNameBindings: ['computedStyle', 'computedSize'],
   attributeBindings: ['type', 'role', 'data-toggle', 'haspopup', 'aria-expanded'],
   id: '',
 
   //Defaults
+  type: 'button',
   role: 'button',
   style: null,
   size: null,

--- a/addon/components/rui-dropdown-trigger/component.js
+++ b/addon/components/rui-dropdown-trigger/component.js
@@ -18,8 +18,8 @@ export default Ember.Component.extend({
 
   //Constructors
   classPrefix: 'btn',
-  styles: ['default', 'primary', 'success', 'warning', 'danger', 'info', 'link'],
-  sizes: ['lg', 'sm', 'xs'],
+  styles: ['secondary', 'primary', 'success', 'warning', 'danger', 'info', 'link'],
+  sizes: ['lg', 'sm'],
 
   // Data Attrs, required by bootstrap
   'data-toggle': 'dropdown',

--- a/addon/components/rui-dropdown-trigger/component.js
+++ b/addon/components/rui-dropdown-trigger/component.js
@@ -6,12 +6,11 @@ export default Ember.Component.extend({
   tagName: 'button',
   classNames: ['dropdown-toggle'],
   classNameBindings: ['computedStyle', 'computedSize'],
-  attributeBindings: ['type', 'role', 'data-toggle', 'haspopup', 'aria-expanded'],
+  attributeBindings: ['type', 'data-toggle', 'haspopup', 'aria-expanded'],
   id: '',
 
   //Defaults
   type: 'button',
-  role: 'button',
   style: null,
   size: null,
   caret: true,

--- a/addon/components/rui-dropdown-trigger/template.hbs
+++ b/addon/components/rui-dropdown-trigger/template.hbs
@@ -1,4 +1,9 @@
-{{yield}}
+{{#if hasBlock}}
+  {{yield}}
+{{else}}
+  <span class="sr-only">Toggle Dropdown</span>
+{{/if}}
 {{#if caret}}
   <span class='caret'></span>
 {{/if}}
+

--- a/addon/components/rui-dropdown/component.js
+++ b/addon/components/rui-dropdown/component.js
@@ -10,5 +10,4 @@ export default Ember.Component.extend({
   // Defaults
   dropup: false,
   role: 'group'
-
 });

--- a/addon/components/rui-dropdown/component.js
+++ b/addon/components/rui-dropdown/component.js
@@ -3,33 +3,12 @@ import layout from './template';
 
 export default Ember.Component.extend({
   layout: layout,
-  classNameBindings: ['typeComputed'],
+  classNames: ['btn-group'],
+  classNameBindings: ['dropup'],
   attributeBindings: ['role'],
 
-  // Constructors
-  types: ['dropdown', 'dropup', 'btn-group'],
-
   // Defaults
-  type: null,
-  role: null,
+  dropup: false,
+  role: 'group'
 
-  // Computed
-  typeComputed: Ember.computed('type', function(){
-    var types = this.get('types');
-    var type = this.get('type');
-    var resolvedType = type;
-
-    // Set default and bail out if nothing is passed in
-    if (!this.get('type')) {
-      return 'dropdown';
-    }
-
-    // Catch mispelled or non-existant types and return safe default
-    if (types.indexOf(type) === -1) {
-      resolvedType = 'dropdown';
-      Ember.Logger.warn('rui-dropdown: You specified and unsupported \'type\' property so we\'ve defaulted to the default type: choose from \'dropdown dropup btn-group.\'');
-    }
-
-    return resolvedType;
-  }),
 });

--- a/tests/dummy/app/styles/_variables.scss
+++ b/tests/dummy/app/styles/_variables.scss
@@ -26,6 +26,7 @@
 //
 // Grayscale and brand colors for use across Bootstrap.
 
+
 $gray-dark:                 #373a3c !default;
 $gray:                      #55595c !default;
 $gray-light:                #818a91 !default;
@@ -55,11 +56,11 @@ $enable-hover-media-query:  false !default;
 //
 // Control the default styling of most Bootstrap elements by modifying these
 // variables. Mostly focused on spacing.
-
+$root:                       14;
 $spacer:                     1rem !default;
 $spacer-x:                   $spacer !default;
 $spacer-y:                   $spacer !default;
-$border-width:               .0625rem !default;
+$border-width:               1 / $root * 1rem !default; //.0675rem !default;
 
 
 // Body
@@ -128,7 +129,7 @@ $font-family-monospace:      Menlo, Monaco, Consolas, "Courier New", monospace !
 $font-family-base:           $font-family-sans-serif !default;
 
 // Pixel value used to responsively scale all typography. Applied to the `<html>` element.
-$font-size-root:             16px !default;
+$font-size-root:             $root * 1px !default;
 
 $font-size-base:             1rem !default;
 $font-size-lg:               1.25rem !default;

--- a/tests/dummy/app/styles/_variables.scss
+++ b/tests/dummy/app/styles/_variables.scss
@@ -122,7 +122,7 @@ $grid-gutter-width:          1.875rem !default; // 30px
 //
 // Font, line-height, and color for body text, headings, and more.
 
-$font-family-sans-serif:     "Helvetica Neue", Helvetica, Arial, sans-serif !default;
+$font-family-sans-serif:     "Open Sans", Helvetica, Arial, sans-serif !default;
 $font-family-serif:          Georgia, "Times New Roman", Times, serif !default;
 $font-family-monospace:      Menlo, Monaco, Consolas, "Courier New", monospace !default;
 $font-family-base:           $font-family-sans-serif !default;

--- a/tests/dummy/app/templates/partials/_dropdowns.hbs
+++ b/tests/dummy/app/templates/partials/_dropdowns.hbs
@@ -8,23 +8,17 @@
     <thead>
       <tr>
         <th>Property</th>
-        <th>Attribute Types</th>
-        <th>Available Options</th>
-        <th>secondary</th>
+        <th>Type</th>
+        <th>Options</th>
+        <th>Default</th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <td>type</td>
-        <td>[string]</td>
-        <td>'dropdown', 'dropup', 'button-group'</td>
-        <td>'dropdown'</td>
-      </tr>
-      <tr>
-        <td>role</td>
-        <td>[string]</td>
-        <td>'group'</td>
-        <td>null</td>
+        <td><strong>dropup</strong></td>
+        <td>[boolean]</td>
+        <td>true/false</td>
+        <td>false</td>
       </tr>
     </tbody>
   </table>
@@ -40,34 +34,34 @@
     <thead>
       <tr>
         <th>Property</th>
-        <th>Attribute Types</th>
-        <th>Available Options</th>
-        <th>secondary</th>
+        <th>Type</th>
+        <th>Options</th>
+        <th>Default</th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <td>id</td>
+        <td><strong>id</strong></td>
         <td>[string]</td>
         <td>user defined - should correspond to <code>aria-labelledby</code> of <code>&lbrace;&lbrace;rui-dropdown-menu&rbrace;&rbrace;</code></td>
         <td>-</td>
       </tr>
       <tr>
-        <td>styles</td>
+        <td><strong>styles</strong></td>
         <td>[string]</td>
-        <td>'secondary', 'primary', 'success', 'info', 'warning', 'danger', 'link'</td>
+        <td>'primary', 'secondary', 'success', 'warning', 'danger', 'info', 'link'</td>
         <td>null</td>
       </tr>
       <tr>
-        <td>size</td>
+        <td><strong>size</strong></td>
         <td>[string]</td>
         <td>'lg', 'sm'</td>
         <td>null</td>
       </tr>
       <tr>
-        <td>caret</td>
+        <td><strong>caret</strong></td>
         <td>[boolean]</td>
-        <td>true/false</td>
+        <td>true/false* - TBD: currently defunct in BS4 as is now applied via :after psuedo class</td>
         <td>true</td>
       </tr>
     </tbody>
@@ -84,20 +78,20 @@
     <thead>
       <tr>
         <th>Property</th>
-        <th>Attribute Types</th>
-        <th>Available Options</th>
-        <th>secondary</th>
+        <th>Type</th>
+        <th>Options</th>
+        <th>Default</th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <td>align</td>
+        <td><strong>align</strong></td>
         <td>[string]</td>
         <td>'left', 'right'</td>
         <td>null</td>
       </tr>
       <tr>
-        <td>aria-labelledby</td>
+        <td><strong>aria-labelledby</strong></td>
         <td>[string]</td>
         <td>user defined - should correspond to <code>id</code> of <code>&lbrace;&lbrace;rui-dropdown-trigger&rbrace;&rbrace;</code></td>
         <td>-</td>
@@ -119,9 +113,11 @@
       {{/rui-dropdown-trigger}}
 
       {{#rui-dropdown-menu aria-labelledby='myDropdown'}}
-        <li><a href='#'>Item 1</a></li>
-        <li><a href='#'>Item 2</a></li>
-        <li><a href='#'>Item 3</a></li>
+        <h6 class="dropdown-header">Header</h6>
+        <a href='#' class='dropdown-item'>Item 1</a>
+        <a href='#' class='dropdown-item'>Item 2</a>
+        <div class="dropdown-divider"></div>
+        <a href='#' class='dropdown-item'>Item 3</a>
       {{/rui-dropdown-menu}}
     {{/rui-dropdown}}
 
@@ -131,16 +127,16 @@
       {{/rui-dropdown-trigger}}
 
       {{#rui-dropdown-menu aria-labelledby='myDropdown2'}}
-        <li><a href='#'>Item 1</a></li>
-        <li><a href='#'>Item 2</a></li>
-        <li><a href='#'>Item 3</a></li>
+        <a href='#' class='dropdown-item'>Item 1</a>
+        <a href='#' class='dropdown-item'>Item 2</a>
+        <a href='#' class='dropdown-item'>Item 3</a>
       {{/rui-dropdown-menu}}
     {{/rui-dropdown}}
   </div>
   <div class="panel-footer">
     <pre><code class="handlebars">
 &lt;!-- Basic Dropdown --&gt;
-&lbrace;&lbrace;#rui-dropdown type='dropdown'&rbrace;&rbrace;
+&lbrace;&lbrace;#rui-dropdown&rbrace;&rbrace;
 
   &lt;!-- Include a trigger component --&gt;
   &lbrace;&lbrace;#rui-dropdown-trigger id='myDropdown' style='secondary'&rbrace;&rbrace;
@@ -149,9 +145,11 @@
 
   &lt;!-- Include a menu component --&gt;
   &lbrace;&lbrace;#rui-dropdown-menu aria-labelledby='myDropdown'&rbrace;&rbrace;
-    &lt;li&gt;&lt;a href='#'&gt;Item 1&lt;/a&gt;&lt;/li&gt;
-    &lt;li&gt;&lt;a href='#'&gt;Item 2&lt;/a&gt;&lt;/li&gt;
-    &lt;li&gt;&lt;a href='#'&gt;Item 3&lt;/a&gt;&lt;/li&gt;
+    &lt;h6 class=&quot;dropdown-header&quot;&gt;Header&lt;/h6&gt;
+    &lt;a href='#' class='dropdown-item'&gt;Item 1&lt;/a&gt;
+    &lt;a href='#' class='dropdown-item'&gt;Item 2&lt;/a&gt;
+    &lt;div class=&quot;dropdown-divider&quot;&gt;&lt;/div&gt;
+    &lt;a href='#' class='dropdown-item'&gt;Item 3&lt;/a&gt;
   &lbrace;&lbrace;/rui-dropdown-menu&rbrace;&rbrace;
 
 &lbrace;&lbrace;/rui-dropdown&rbrace;&rbrace;
@@ -166,17 +164,16 @@
 <p>Split button and dropdowns included must be wrapped within a <code>btn-group</code> and have the <code>type='btn-group'</code> on the dropdown component.  Don't forget to specify the <code>role='group'</code> to help out the screen readers.</p>
 <div class="panel panel-secondary panel-code-example">
   <div class="panel-body">
-    <div class='btn-group'>
-      {{#rui-button}}Button{{/rui-button}}
-      {{#rui-dropdown}}
-        {{rui-dropdown-trigger id='myDropdown3' style='secondary'}}
-        {{#rui-dropdown-menu aria-labelledby='myDropdown3' align='right'}}
-          <li><a href='#'>Item 1</a></li>
-          <li><a href='#'>Item 2</a></li>
-          <li><a href='#'>Item 3</a></li>
-        {{/rui-dropdown-menu}}
-      {{/rui-dropdown}}
-    </div>
+    {{#rui-dropdown}}
+      {{#rui-button style='secondary'}}Button{{/rui-button}}
+      {{rui-dropdown-trigger id='myDropdown3' style='secondary'}}
+      {{#rui-dropdown-menu aria-labelledby='myDropdown3'}}
+        <a href='#' class='dropdown-item'>Item 1</a>
+        <a href='#' class='dropdown-item'>Item 2</a>
+        <a href='#' class='dropdown-item'>Item 3</a>
+      {{/rui-dropdown-menu}}
+    {{/rui-dropdown}}
+
     <div class='btn-group'>
       {{#rui-button style='primary'}}Button{{/rui-button}}
       {{#rui-button style='primary'}}Button{{/rui-button}}
@@ -184,10 +181,10 @@
         {{#rui-dropdown-trigger id='myDropdown4' style='primary'}}
           Dropdown
         {{/rui-dropdown-trigger}}
-        {{#rui-dropdown-menu aria-labelledby='myDropdown4' align='right'}}
-          <li><a href='#'>Item 1</a></li>
-          <li><a href='#'>Item 2</a></li>
-          <li><a href='#'>Item 3</a></li>
+        {{#rui-dropdown-menu aria-labelledby='myDropdown4'}}
+          <a href='#' class='dropdown-item'>Item 1</a>
+          <a href='#' class='dropdown-item'>Item 2</a>
+          <a href='#' class='dropdown-item'>Item 3</a>
         {{/rui-dropdown-menu}}
       {{/rui-dropdown}}
     </div>
@@ -195,17 +192,27 @@
   </div>
   <div class="panel-footer">
     <pre><code class="handlebars">
-&lt;!-- Basic Dropdown --&gt;
-&lt;div class='btn-group'&gt;
-  &lbrace;&lbrace;#rui-button&rbrace;&rbrace;Button&lbrace;&lbrace;/rui-button&rbrace;&rbrace;
+&lt;!-- Split Dropdown --&gt;
+&lbrace;&lbrace;#rui-dropdown&rbrace;&rbrace;
+  &lbrace;&lbrace;#rui-button style='secondary'&rbrace;&rbrace;Button&lbrace;&lbrace;/rui-button&rbrace;&rbrace;
+  &lbrace;&lbrace;rui-dropdown-trigger id='myDropdown3' style='secondary'&rbrace;&rbrace;
+  &lbrace;&lbrace;#rui-dropdown-menu aria-labelledby='myDropdown3'&rbrace;&rbrace;
+      &lt;a href='#' class='dropdown-item'&gt;Item 1&lt;/a&gt;
+      &lt;a href='#' class='dropdown-item'&gt;Item 2&lt;/a&gt;
+      &lt;a href='#' class='dropdown-item'&gt;Item 3&lt;/a&gt;
+  &lbrace;&lbrace;/rui-dropdown-menu&rbrace;&rbrace;
+&lbrace;&lbrace;/rui-dropdown&rbrace;&rbrace;
 
-  &lt;!-- Set type'btn-group' and role='group' --&gt;
+&lt;!-- Button Group Dropdown --&gt;
+&lt;div class='btn-group'&gt;
+  &lbrace;&lbrace;#rui-button style='primary'&rbrace;&rbrace;Button&lbrace;&lbrace;/rui-button&rbrace;&rbrace;
+  &lbrace;&lbrace;#rui-button style='primary'&rbrace;&rbrace;Button&lbrace;&lbrace;/rui-button&rbrace;&rbrace;
   &lbrace;&lbrace;#rui-dropdown&rbrace;&rbrace;
-    &lbrace;&lbrace;rui-dropdown-trigger id='myDropdown2' style='secondary'&rbrace;&rbrace;
-    &lbrace;&lbrace;#rui-dropdown-menu aria-labelledby='myDropdown2' align='right'&rbrace;&rbrace;
-      &lt;li&gt;&lt;a href='#'&gt;Item 1&lt;/a&gt;&lt;/li&gt;
-      &lt;li&gt;&lt;a href='#'&gt;Item 2&lt;/a&gt;&lt;/li&gt;
-      &lt;li&gt;&lt;a href='#'&gt;Item 3&lt;/a&gt;&lt;/li&gt;
+    &lbrace;&lbrace;rui-dropdown-trigger id='myDropdown4' style='primary'&rbrace;&rbrace;
+    &lbrace;&lbrace;#rui-dropdown-menu aria-labelledby='myDropdown4'&rbrace;&rbrace;
+        &lt;a href='#' class='dropdown-item'&gt;Item 1&lt;/a&gt;
+        &lt;a href='#' class='dropdown-item'&gt;Item 2&lt;/a&gt;
+        &lt;a href='#' class='dropdown-item'&gt;Item 3&lt;/a&gt;
     &lbrace;&lbrace;/rui-dropdown-menu&rbrace;&rbrace;
   &lbrace;&lbrace;/rui-dropdown&rbrace;&rbrace;
 &lt;/div&gt;
@@ -226,26 +233,24 @@
           Dropup
         {{/rui-dropdown-trigger}}
         {{#rui-dropdown-menu aria-labelledby='myDropdown5'}}
-          <li><a href='#'>Item 1</a></li>
-          <li><a href='#'>Item 2</a></li>
-          <li><a href='#'>Item 3</a></li>
+          <a href='#' class='dropdown-item'>Item 1</a>
+          <a href='#' class='dropdown-item'>Item 2</a>
+          <a href='#' class='dropdown-item'>Item 3</a>
         {{/rui-dropdown-menu}}
       {{/rui-dropdown}}
     </div>
   </div>
   <div class="panel-footer">
     <pre><code class="handlebars">
-&lt;!-- Basic Dropup --&gt;
-
 &lt;!-- Add dropup=true --&gt;
 &lbrace;&lbrace;#rui-dropdown dropup=true&rbrace;&rbrace;
   &lbrace;&lbrace;#rui-dropdown-trigger id='myDropup' style='secondary'&rbrace;&rbrace;
     Dropup
   &lbrace;&lbrace;/rui-dropdown-trigger&rbrace;&rbrace;
   &lbrace;&lbrace;#rui-dropdown-menu aria-labelledby='myDropup'&rbrace;&rbrace;
-    &lt;li&gt;&lt;a href='#'&gt;Item 1&lt;/a&gt;&lt;/li&gt;
-    &lt;li&gt;&lt;a href='#'&gt;Item 2&lt;/a&gt;&lt;/li&gt;
-    &lt;li&gt;&lt;a href='#'&gt;Item 3&lt;/a&gt;&lt;/li&gt;
+    &lt;a href='#' class='dropdown-item'&gt;Item 1&lt;/a&gt;
+    &lt;a href='#' class='dropdown-item'&gt;Item 2&lt;/a&gt;
+    &lt;a href='#' class='dropdown-item'&gt;Item 3&lt;/a&gt;
   &lbrace;&lbrace;/rui-dropdown-menu&rbrace;&rbrace;
 &lbrace;&lbrace;/rui-dropdown&rbrace;&rbrace;
     </code></pre>
@@ -264,9 +269,9 @@
         Left
       {{/rui-dropdown-trigger}}
       {{#rui-dropdown-menu aria-labelledby='myDropdown6'}}
-        <li><a href='#'>Item 1</a></li>
-        <li><a href='#'>Item 2</a></li>
-        <li><a href='#'>Item 3</a></li>
+        <a href='#' class='dropdown-item'>Item 1</a>
+        <a href='#' class='dropdown-item'>Item 2</a>
+        <a href='#' class='dropdown-item'>Item 3</a>
       {{/rui-dropdown-menu}}
     {{/rui-dropdown}}
 
@@ -275,9 +280,9 @@
         Right
       {{/rui-dropdown-trigger}}
       {{#rui-dropdown-menu aria-labelledby='myDropdown7' align='right'}}
-        <li><a href='#'>Item 1</a></li>
-        <li><a href='#'>Item 2</a></li>
-        <li><a href='#'>Item 3</a></li>
+        <a href='#' class='dropdown-item'>Item 1</a>
+        <a href='#' class='dropdown-item'>Item 2</a>
+        <a href='#' class='dropdown-item'>Item 3</a>
       {{/rui-dropdown-menu}}
     {{/rui-dropdown}}
   </div>
@@ -285,15 +290,15 @@
     <pre><code class="handlebars">
 &lt;!-- Align right --&gt;
 &lbrace;&lbrace;#rui-dropdown&rbrace;&rbrace;
-  &lbrace;&lbrace;#rui-dropdown-trigger id='myDropdown2' style='secondary'&rbrace;&rbrace;
+  &lbrace;&lbrace;#rui-dropdown-trigger id='myDropdown7' style='secondary'&rbrace;&rbrace;
     Right
   &lbrace;&lbrace;/rui-dropdown-trigger&rbrace;&rbrace;
 
   &lt;!-- Add align='right' or align='left' to override however secondarys to left --&gt;
-  &lbrace;&lbrace;#rui-dropdown-menu aria-labelledby='myDropdown2' align='right'&rbrace;&rbrace;
-    &lt;li&gt;&lt;a href='#'&gt;Item 1&lt;/a&gt;&lt;/li&gt;
-    &lt;li&gt;&lt;a href='#'&gt;Item 2&lt;/a&gt;&lt;/li&gt;
-    &lt;li&gt;&lt;a href='#'&gt;Item 3&lt;/a&gt;&lt;/li&gt;
+  &lbrace;&lbrace;#rui-dropdown-menu aria-labelledby='myDropdown7' align='right'&rbrace;&rbrace;
+    &lt;a href='#' class='dropdown-item'&gt;Item 1&lt;/a&gt;
+    &lt;a href='#' class='dropdown-item'&gt;Item 2&lt;/a&gt;
+    &lt;a href='#' class='dropdown-item'&gt;Item 3&lt;/a&gt;
   &lbrace;&lbrace;/rui-dropdown-menu&rbrace;&rbrace;
 &lbrace;&lbrace;/rui-dropdown&rbrace;&rbrace;
     </code></pre>

--- a/tests/dummy/app/templates/partials/_dropdowns.hbs
+++ b/tests/dummy/app/templates/partials/_dropdowns.hbs
@@ -10,7 +10,7 @@
         <th>Property</th>
         <th>Attribute Types</th>
         <th>Available Options</th>
-        <th>Default</th>
+        <th>secondary</th>
       </tr>
     </thead>
     <tbody>
@@ -35,14 +35,14 @@
     {{header-anchor name='dropdown-trigger' data-title='Dropdown Trigger'}}
     <small><code>&lbrace;&lbrace;rui-dropdown-trigger&rbrace;&rbrace;</code></small>
   </h1>
-  <p>The <code>&lbrace;&lbrace;rui-dropdown-trigger&rbrace;&rbrace;</code> must be contained within a <code>&lbrace;&lbrace;rui-dropdown&rbrace;&rbrace;</code> and is the button element which triggers the sibling <code>&lbrace;&lbrace;rui-dropdown-menu&rbrace;&rbrace;</code> on click.  It accepts a block and is built to be highly customizable, therefore we do not inlcude any styling by default.</p>
+  <p>The <code>&lbrace;&lbrace;rui-dropdown-trigger&rbrace;&rbrace;</code> must be contained within a <code>&lbrace;&lbrace;rui-dropdown&rbrace;&rbrace;</code> and is the button element which triggers the sibling <code>&lbrace;&lbrace;rui-dropdown-menu&rbrace;&rbrace;</code> on click.  It accepts a block and is built to be highly customizable, therefore we do not inlcude any styling by secondary.</p>
   <table class='table'>
     <thead>
       <tr>
         <th>Property</th>
         <th>Attribute Types</th>
         <th>Available Options</th>
-        <th>Default</th>
+        <th>secondary</th>
       </tr>
     </thead>
     <tbody>
@@ -92,7 +92,7 @@
         <th>Property</th>
         <th>Attribute Types</th>
         <th>Available Options</th>
-        <th>Default</th>
+        <th>secondary</th>
       </tr>
     </thead>
     <tbody>
@@ -116,11 +116,11 @@
 <h3>
   {{header-anchor name='dropdown-basic-example' data-title='Basic Example'}}
 </h3>
-<p>Basic dropdown configurations required are shown below.  The <code>id</code> and <code>aria-labelledby</code> should match for accessability compliance.  You must define a style attribute on the dropdown trigger as we omit all styles by default to allow for greatest felxibility.</p>
-<div class="panel panel-default panel-code-example">
+<p>Basic dropdown configurations required are shown below.  The <code>id</code> and <code>aria-labelledby</code> should match for accessability compliance.  You must define a style attribute on the dropdown trigger as we omit all styles by secondary to allow for greatest felxibility.</p>
+<div class="panel panel-secondary panel-code-example">
   <div class="panel-body">
-    {{#rui-dropdown type='btn-group'}}
-      {{#rui-dropdown-trigger id='myDropdown' style='default'}}
+    {{#rui-dropdown}}
+      {{#rui-dropdown-trigger id='myDropdown' style='secondary'}}
         Menu
       {{/rui-dropdown-trigger}}
 
@@ -149,7 +149,7 @@
 &lbrace;&lbrace;#rui-dropdown type='dropdown'&rbrace;&rbrace;
 
   &lt;!-- Include a trigger component --&gt;
-  &lbrace;&lbrace;#rui-dropdown-trigger id='myDropdown' style='default'&rbrace;&rbrace;
+  &lbrace;&lbrace;#rui-dropdown-trigger id='myDropdown' style='secondary'&rbrace;&rbrace;
     Menu
   &lbrace;&lbrace;/rui-dropdown-trigger&rbrace;&rbrace;
 
@@ -170,12 +170,12 @@
   {{header-anchor name='dropdown-split-button' data-title='Split Button'}}
 </h3>
 <p>Split button and dropdowns included must be wrapped within a <code>btn-group</code> and have the <code>type='btn-group'</code> on the dropdown component.  Don't forget to specify the <code>role='group'</code> to help out the screen readers.</p>
-<div class="panel panel-default panel-code-example">
+<div class="panel panel-secondary panel-code-example">
   <div class="panel-body">
     <div class='btn-group'>
       {{#rui-button}}Button{{/rui-button}}
-      {{#rui-dropdown type='btn-group' role='group'}}
-        {{rui-dropdown-trigger id='myDropdown3' style='default'}}
+      {{#rui-dropdown}}
+        {{rui-dropdown-trigger id='myDropdown3' style='secondary'}}
         {{#rui-dropdown-menu aria-labelledby='myDropdown3' align='right'}}
           <li><a href='#'>Item 1</a></li>
           <li><a href='#'>Item 2</a></li>
@@ -186,7 +186,7 @@
     <div class='btn-group'>
       {{#rui-button style='primary'}}Button{{/rui-button}}
       {{#rui-button style='primary'}}Button{{/rui-button}}
-      {{#rui-dropdown type='btn-group' role='group'}}
+      {{#rui-dropdown}}
         {{#rui-dropdown-trigger id='myDropdown4' style='primary'}}
           Dropdown
         {{/rui-dropdown-trigger}}
@@ -206,8 +206,8 @@
   &lbrace;&lbrace;#rui-button&rbrace;&rbrace;Button&lbrace;&lbrace;/rui-button&rbrace;&rbrace;
 
   &lt;!-- Set type'btn-group' and role='group' --&gt;
-  &lbrace;&lbrace;#rui-dropdown type='btn-group' role='group'&rbrace;&rbrace;
-    &lbrace;&lbrace;rui-dropdown-trigger id='myDropdown2' style='default'&rbrace;&rbrace;
+  &lbrace;&lbrace;#rui-dropdown&rbrace;&rbrace;
+    &lbrace;&lbrace;rui-dropdown-trigger id='myDropdown2' style='secondary'&rbrace;&rbrace;
     &lbrace;&lbrace;#rui-dropdown-menu aria-labelledby='myDropdown2' align='right'&rbrace;&rbrace;
       &lt;li&gt;&lt;a href='#'&gt;Item 1&lt;/a&gt;&lt;/li&gt;
       &lt;li&gt;&lt;a href='#'&gt;Item 2&lt;/a&gt;&lt;/li&gt;
@@ -223,12 +223,12 @@
 <h3>
   {{header-anchor name='dropdown-dropups' data-title='Dropups'}}
 </h3>
-<p>Add <code>type='dropup'</code> to the dropdown component to position the menu above the trigger element.</p>
-<div class="panel panel-default panel-code-example">
+<p>Add <code>dropup=true</code> to the dropdown component to position the menu above the trigger element.</p>
+<div class="panel panel-secondary panel-code-example">
   <div class="panel-body">
     <div class='btn-group'>
-      {{#rui-dropdown type='dropup' role='group'}}
-        {{#rui-dropdown-trigger id='myDropdown5' style='default'}}
+      {{#rui-dropdown dropup=true}}
+        {{#rui-dropdown-trigger id='myDropdown5' style='secondary'}}
           Dropup
         {{/rui-dropdown-trigger}}
         {{#rui-dropdown-menu aria-labelledby='myDropdown5'}}
@@ -243,9 +243,9 @@
     <pre><code class="handlebars">
 &lt;!-- Basic Dropup --&gt;
 
-&lt;!-- Add type='dropup' --&gt;
-&lbrace;&lbrace;#rui-dropdown type='dropup' &rbrace;&rbrace;
-  &lbrace;&lbrace;#rui-dropdown-trigger id='myDropup' style='default'&rbrace;&rbrace;
+&lt;!-- Add dropup=true --&gt;
+&lbrace;&lbrace;#rui-dropdown dropup=true&rbrace;&rbrace;
+  &lbrace;&lbrace;#rui-dropdown-trigger id='myDropup' style='secondary'&rbrace;&rbrace;
     Dropup
   &lbrace;&lbrace;/rui-dropdown-trigger&rbrace;&rbrace;
   &lbrace;&lbrace;#rui-dropdown-menu aria-labelledby='myDropup'&rbrace;&rbrace;
@@ -262,11 +262,11 @@
 <h3>
   {{header-anchor name='dropdown-alignment' data-title='Alignment'}}
 </h3>
-<p>Add <code>align='right'</code> to the dropdown-menu component to align the menu to the right of the button. Alignment defaults to the left without declaring.  You can declare <code>align='left'</code> to override other behavoirs which might align it right.</p>
-<div class="panel panel-default panel-code-example">
+<p>Add <code>align='right'</code> to the dropdown-menu component to align the menu to the right of the button. Alignment secondarys to the left without declaring.  You can declare <code>align='left'</code> to override other behavoirs which might align it right.</p>
+<div class="panel panel-secondary panel-code-example">
   <div class="panel-body">
-    {{#rui-dropdown type='btn-group' role='group'}}
-      {{#rui-dropdown-trigger id='myDropdown6' style='default'}}
+    {{#rui-dropdown}}
+      {{#rui-dropdown-trigger id='myDropdown6' style='secondary'}}
         Left
       {{/rui-dropdown-trigger}}
       {{#rui-dropdown-menu aria-labelledby='myDropdown6'}}
@@ -276,8 +276,8 @@
       {{/rui-dropdown-menu}}
     {{/rui-dropdown}}
 
-    {{#rui-dropdown type='btn-group' role='group'}}
-      {{#rui-dropdown-trigger id='myDropdown7' style='default'}}
+    {{#rui-dropdown}}
+      {{#rui-dropdown-trigger id='myDropdown7' style='secondary'}}
         Right
       {{/rui-dropdown-trigger}}
       {{#rui-dropdown-menu aria-labelledby='myDropdown7' align='right'}}
@@ -290,12 +290,12 @@
   <div class="panel-footer">
     <pre><code class="handlebars">
 &lt;!-- Align right --&gt;
-&lbrace;&lbrace;#rui-dropdown type='btn-group' role='group'&rbrace;&rbrace;
-  &lbrace;&lbrace;#rui-dropdown-trigger id='myDropdown2' style='default'&rbrace;&rbrace;
+&lbrace;&lbrace;#rui-dropdown&rbrace;&rbrace;
+  &lbrace;&lbrace;#rui-dropdown-trigger id='myDropdown2' style='secondary'&rbrace;&rbrace;
     Right
   &lbrace;&lbrace;/rui-dropdown-trigger&rbrace;&rbrace;
 
-  &lt;!-- Add align='right' or align='left' to override however defaults to left --&gt;
+  &lt;!-- Add align='right' or align='left' to override however secondarys to left --&gt;
   &lbrace;&lbrace;#rui-dropdown-menu aria-labelledby='myDropdown2' align='right'&rbrace;&rbrace;
     &lt;li&gt;&lt;a href='#'&gt;Item 1&lt;/a&gt;&lt;/li&gt;
     &lt;li&gt;&lt;a href='#'&gt;Item 2&lt;/a&gt;&lt;/li&gt;

--- a/tests/dummy/app/templates/partials/_dropdowns.hbs
+++ b/tests/dummy/app/templates/partials/_dropdowns.hbs
@@ -53,21 +53,15 @@
         <td>-</td>
       </tr>
       <tr>
-        <td>tagName</td>
-        <td>[string]</td>
-        <td>'button', 'a'</td>
-        <td>'button'</td>
-      </tr>
-      <tr>
         <td>styles</td>
         <td>[string]</td>
-        <td>'standard', 'primary', 'success', 'info', 'warning', 'danger', 'link'</td>
+        <td>'secondary', 'primary', 'success', 'info', 'warning', 'danger', 'link'</td>
         <td>null</td>
       </tr>
       <tr>
         <td>size</td>
         <td>[string]</td>
-        <td>'lg', 'sm', 'xs'</td>
+        <td>'lg', 'sm'</td>
         <td>null</td>
       </tr>
       <tr>


### PR DESCRIPTION
- Retrofits dropdown components to compy with BS4 syntax
- Sets base font variable to 14px from 16px
- Fixes border width bug introduced with reduced base font size
- Removes tagName option and subsequent 'role' attribute binding from dropdown trigger (we will now assume all dropdown triggers can be 'button' elements)
- Remove type option from dropdown, always emitted with 'btn-group' class and 'dropup' class appended based on boolean, 'dropdown' class removed.
- All dropdown documentation updated