### PR TITLE
Fix Broken Specs

### DIFF
--- a/addon/components/rui-nav-brand-dropdown/component.js
+++ b/addon/components/rui-nav-brand-dropdown/component.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import layout from './template';
 import RuiDropdownComponent from 'ember-cli-revelation-ui/components/rui-dropdown/component';
 

--- a/addon/components/rui-nav-project-dropdown/component.js
+++ b/addon/components/rui-nav-project-dropdown/component.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import layout from './template';
 import RuiDropdownComponent from 'ember-cli-revelation-ui/components/rui-dropdown/component';
 

--- a/addon/components/rui-nav-user-dropdown/component.js
+++ b/addon/components/rui-nav-user-dropdown/component.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import layout from './template';
 import RuiDropdownComponent from 'ember-cli-revelation-ui/components/rui-dropdown/component';
 

--- a/app/helpers/is-equal.js
+++ b/app/helpers/is-equal.js
@@ -1,0 +1,1 @@
+export { default, isEqual } from 'ember-cli-revelation-ui/helpers/is-equal';

--- a/app/helpers/is-not.js
+++ b/app/helpers/is-not.js
@@ -1,0 +1,1 @@
+export { default, isNot } from 'ember-cli-revelation-ui/helpers/is-not';

--- a/app/helpers/read-path.js
+++ b/app/helpers/read-path.js
@@ -1,0 +1,1 @@
+export { default, readPath } from 'ember-cli-revelation-ui/helpers/read-path';

--- a/tests/dummy/app/templates/components.hbs
+++ b/tests/dummy/app/templates/components.hbs
@@ -25,7 +25,7 @@
         {{partial 'partials/dropdowns'}}
         {{partial 'partials/icons'}}
         {{partial 'partials/spinner'}}
-        {{partial 'partials/text_input'}}
+        {{partial 'partials/input_text'}}
         {{partial 'partials/nav_vertical'}}
 
         {{!-- Just in case ... --}}

--- a/tests/dummy/app/templates/partials/_input_text.hbs
+++ b/tests/dummy/app/templates/partials/_input_text.hbs
@@ -1,7 +1,7 @@
 <section>
   <h1 class='page-header'>
     {{header-anchor name='input-text' data-title='Input (text)'}}
-    <small><code>&lbrace;&lbrace;rui-text-input&rbrace;&rbrace;</code></small>
+    <small><code>&lbrace;&lbrace;rui-input-text&rbrace;&rbrace;</code></small>
   </h1>
   <p>Extends Ember.TextField with default classnames and additional options. <a href='http://emberjs.com/api/classes/Ember.TextField.html' target="blank">See Ember.TextField</a></p>
   <div class='card card-code-example'>

--- a/tests/integration/components/rui-avatar/component-test.js
+++ b/tests/integration/components/rui-avatar/component-test.js
@@ -6,7 +6,7 @@ moduleForComponent('rui-avatar', 'Integration | Component | rui avatar', {
 });
 
 test('it renders', function(assert) {
-  assert.expect(2);
+  assert.expect(1);
 
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
@@ -14,13 +14,4 @@ test('it renders', function(assert) {
   this.render(hbs`{{rui-avatar}}`);
 
   assert.equal(this.$().text().trim(), '');
-
-  // Template block usage:
-  this.render(hbs`
-    {{#rui-avatar}}
-      template block text
-    {{/rui-avatar}}
-  `);
-
-  assert.equal(this.$().text().trim(), 'template block text');
 });

--- a/tests/integration/components/rui-icon/component-test.js
+++ b/tests/integration/components/rui-icon/component-test.js
@@ -6,7 +6,7 @@ moduleForComponent('rui-icon', 'Integration | Component | rui icon', {
 });
 
 test('it renders', function(assert) {
-  assert.expect(2);
+  assert.expect(1);
 
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
@@ -14,13 +14,4 @@ test('it renders', function(assert) {
   this.render(hbs`{{rui-icon}}`);
 
   assert.equal(this.$().text().trim(), '');
-
-  // Template block usage:
-  this.render(hbs`
-    {{#rui-icon}}
-      template block text
-    {{/rui-icon}}
-  `);
-
-  assert.equal(this.$().text().trim(), 'template block text');
 });

--- a/tests/integration/components/rui-input-text/component-test.js
+++ b/tests/integration/components/rui-input-text/component-test.js
@@ -1,26 +1,17 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-moduleForComponent('rui-text-input', 'Integration | Component | rui text input', {
+moduleForComponent('rui-input-text', 'Integration | Component | rui input text', {
   integration: true
 });
 
 test('it renders', function(assert) {
-  assert.expect(2);
+  assert.expect(1);
 
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
 
-  this.render(hbs`{{rui-text-input}}`);
+  this.render(hbs`{{rui-input-text}}`);
 
   assert.equal(this.$().text().trim(), '');
-
-  // Template block usage:
-  this.render(hbs`
-    {{#rui-text-input}}
-      template block text
-    {{/rui-text-input}}
-  `);
-
-  assert.equal(this.$().text().trim(), 'template block text');
 });

--- a/tests/integration/components/rui-nav-brand-dropdown/component-test.js
+++ b/tests/integration/components/rui-nav-brand-dropdown/component-test.js
@@ -1,3 +1,5 @@
+/* global QUnit */
+
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -5,7 +7,9 @@ moduleForComponent('rui-nav-brand-dropdown', 'Integration | Component | rui nav 
   integration: true
 });
 
-test('it renders', function(assert) {
+// TODO: This component spits out HTML stubs. Proper tests need to be written
+//   when the component becomes more dynamic.
+QUnit.skip('it renders', function(assert) {
   assert.expect(2);
 
   // Set any properties with this.set('myProperty', 'value');

--- a/tests/integration/components/rui-nav-project-dropdown/component-test.js
+++ b/tests/integration/components/rui-nav-project-dropdown/component-test.js
@@ -1,3 +1,5 @@
+/* global QUnit */
+
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -5,7 +7,9 @@ moduleForComponent('rui-nav-project-dropdown', 'Integration | Component | rui na
   integration: true
 });
 
-test('it renders', function(assert) {
+// TODO: This component spits out HTML stubs. Proper tests need to be written
+//   when the component becomes more dynamic.
+QUnit.skip('it renders', function(assert) {
   assert.expect(2);
 
   // Set any properties with this.set('myProperty', 'value');

--- a/tests/integration/components/rui-nav-user-dropdown/component-test.js
+++ b/tests/integration/components/rui-nav-user-dropdown/component-test.js
@@ -1,3 +1,5 @@
+/* global QUnit */
+
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -5,7 +7,9 @@ moduleForComponent('rui-nav-user-dropdown', 'Integration | Component | rui nav u
   integration: true
 });
 
-test('it renders', function(assert) {
+// TODO: This component spits out HTML stubs. Proper tests need to be written
+//   when the component becomes more dynamic.
+QUnit.skip('it renders', function(assert) {
   assert.expect(2);
 
   // Set any properties with this.set('myProperty', 'value');

--- a/tests/integration/components/rui-nav-vertical/component-test.js
+++ b/tests/integration/components/rui-nav-vertical/component-test.js
@@ -1,3 +1,5 @@
+/* global QUnit */
+
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -5,7 +7,9 @@ moduleForComponent('rui-nav-vertical', 'Integration | Component | rui nav vertic
   integration: true
 });
 
-test('it renders', function(assert) {
+// TODO: This component spits out HTML stubs. Proper tests need to be written
+//   when the component becomes more dynamic.
+QUnit.skip('it renders', function(assert) {
   assert.expect(2);
 
   // Set any properties with this.set('myProperty', 'value');

--- a/tests/integration/components/rui-select/component-test.js
+++ b/tests/integration/components/rui-select/component-test.js
@@ -6,7 +6,7 @@ moduleForComponent('rui-select', 'Integration | Component | rui select', {
 });
 
 test('it renders', function(assert) {
-  assert.expect(2);
+  assert.expect(1);
 
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
@@ -14,13 +14,4 @@ test('it renders', function(assert) {
   this.render(hbs`{{rui-select}}`);
 
   assert.equal(this.$().text().trim(), '');
-
-  // Template block usage:
-  this.render(hbs`
-    {{#rui-select}}
-      template block text
-    {{/rui-select}}
-  `);
-
-  assert.equal(this.$().text().trim(), 'template block text');
 });

--- a/tests/integration/components/rui-spinner/component-test.js
+++ b/tests/integration/components/rui-spinner/component-test.js
@@ -6,7 +6,7 @@ moduleForComponent('rui-spinner', 'Integration | Component | rui spinner', {
 });
 
 test('it renders', function(assert) {
-  assert.expect(2);
+  assert.expect(1);
 
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
@@ -14,13 +14,4 @@ test('it renders', function(assert) {
   this.render(hbs`{{rui-spinner}}`);
 
   assert.equal(this.$().text().trim(), '');
-
-  // Template block usage:
-  this.render(hbs`
-    {{#rui-spinner}}
-      template block text
-    {{/rui-spinner}}
-  `);
-
-  assert.equal(this.$().text().trim(), 'template block text');
 });

--- a/tests/unit/components/rui-button-test.js
+++ b/tests/unit/components/rui-button-test.js
@@ -28,7 +28,7 @@ test('it adds style class when style property is set', function(assert) {
   Ember.run(function(){
     component.set('style', 'wrongstyle');
   });
-  assert.ok(this.$().hasClass('btn-secondary'), 'it should default to \'btn-default\' class when (unsupported) style is set to \'wrongstyle\'');
+  assert.ok(this.$().hasClass('btn-secondary'), 'it should default to \'btn-secondary\' class when (unsupported) style is set to \'wrongstyle\'');
 
   Ember.run(function(){
     component.set('style', 'primary');

--- a/tests/unit/helpers/is-equal-test.js
+++ b/tests/unit/helpers/is-equal-test.js
@@ -5,6 +5,6 @@ module('Unit | Helper | is equal');
 
 // Replace this with your real tests.
 test('it works', function(assert) {
-  var result = isEqual(42);
+  var result = isEqual([42, 42]);
   assert.ok(result);
 });

--- a/tests/unit/helpers/is-not-test.js
+++ b/tests/unit/helpers/is-not-test.js
@@ -5,6 +5,6 @@ module('Unit | Helper | is not');
 
 // Replace this with your real tests.
 test('it works', function(assert) {
-  var result = isNot(42);
-  assert.ok(result);
+  var result = isNot([42]);
+  assert.notOk(result);
 });

--- a/tests/unit/helpers/read-path-test.js
+++ b/tests/unit/helpers/read-path-test.js
@@ -5,6 +5,8 @@ module('Unit | Helper | read path');
 
 // Replace this with your real tests.
 test('it works', function(assert) {
-  var result = readPath(42);
+  var object = 'object';
+  var path = '1';
+  var result = readPath([object, path]);
   assert.ok(result);
 });


### PR DESCRIPTION
- Write tests for helpers.
- Add missing helper exports.
- Quarantine generated tests for components that spit out static stubs.
- Rename instances of `rui-text-input` to `rui-input-text`.
- Remove generated block tests from self-contained elements.
- Remove Ember import from components that extend another component that
  already imports Ember.

Fixes #71 