### PR TITLE
Select component passes value only on change

### DIFF
--- a/addon/pods/components/rui-select/component.js
+++ b/addon/pods/components/rui-select/component.js
@@ -13,11 +13,11 @@ export default Ember.Component.extend({
   optionValuePath: 'id',
   optionLabelPath: 'title',
   action: Ember.K, // action to fire on change
-  
+
   // shadow the passed-in `selection` to avoid
   // leaking changes to it via a 2-way binding
   _selection: Ember.computed.reads('selection'),
-  
+
   didInitAttrs() {
     this._super(...arguments);
     if (!this.get('content')) {
@@ -30,19 +30,23 @@ export default Ember.Component.extend({
       const selectEl = this.$('select')[0];
       const selectedIndex = selectEl.selectedIndex;
       const content = this.get('content');
-      
+
       // decrement index by 1 if we have a prompt
       const hasPrompt = !!this.get('prompt');
       const contentIndex = hasPrompt ? selectedIndex - 1 : selectedIndex;
-      
+
       const selection = content[contentIndex];
-  
+
       // set the local, shadowed selection to avoid leaking
       // changes to `selection` out via 2-way binding
       this.set('_selection', selection);
-      
       const changeCallback = this.get('action');
-      changeCallback(selection);
+
+      // Return just a single string or integer value even if an object is used
+      const optionValuePath = this.get('optionValuePath');
+      const selectionValue = selection[optionValuePath];
+
+      changeCallback(selectionValue);
     }
   }
 });

--- a/addon/pods/components/rui-select/template.hbs
+++ b/addon/pods/components/rui-select/template.hbs
@@ -4,7 +4,7 @@
       {{prompt}}
     </option>
   {{/if}}
-  
+
   {{#each content key="@identity" as |item|}}
     <option value="{{read-path item optionValuePath}}" selected={{is-equal item selection}}>
       {{read-path item optionLabelPath}}

--- a/tests/dummy/app/templates/partials/_select.hbs
+++ b/tests/dummy/app/templates/partials/_select.hbs
@@ -70,15 +70,13 @@
   <div class="card-block">
     {{rui-select
       content=mySelectOptions
-      optionLabelPath='title'
-      optionValuePath='id'
       selection=mySelectedProp
       prompt="Select Something"
       action=(action (mut mySelectedProp))
     }}
     <br />
     {{#if mySelectedProp}}
-      You've selected: {{mySelectedProp.title}}, the id is: {{mySelectedProp.id}}
+      {{mySelectedProp}}
     {{else}}
       Nothing selected
     {{/if}}


### PR DESCRIPTION
- Select would set bound property to select option object rather than
  desired select option value requiring additional properties and observers on
controller to extract desired value.
- Now sets passed prop value only