### PR TITLE
Bootstrap and ReadMe fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ This README outlines the details of collaborating on this Ember addon.
 ## Installation
 
 * `git clone` this repository
-* `npm install`
-* `bower install`
+* `cd ember-cli-revelation-ui`
+* `npm install && bower install`
 
 ## Running
 
 * `ember server`
-* Visit your app at http://localhost:4200.
+* Visit your app at http://localhost:4210.
 
 ## Running Tests
 

--- a/app/styles/bootstrap/_bootstrap.scss
+++ b/app/styles/bootstrap/_bootstrap.scss
@@ -27,7 +27,7 @@
 @import "../../../bower_components/bootstrap/scss/card";
 // @import "../../../bower_components/bootstrap/scss/breadcrumb";
 @import "../../../bower_components/bootstrap/scss/pagination";
-@import "../../../bower_components/bootstrap/scss/labels";
+@import "../../../bower_components/bootstrap/scss/tags";
 // @import "../../../bower_components/bootstrap/scss/jumbotron";
 @import "../../../bower_components/bootstrap/scss/alert";
 @import "../../../bower_components/bootstrap/scss/progress";


### PR DESCRIPTION
- Add more explicit installation instructions
- Fix port number for running instructions
- Replace deprecated `labels` in bootstrap manifest with `tags`

Fixes #97