### PR TITLE
Select should properly bind in both directions

### DIFF
--- a/addon/pods/components/rui-select/component.js
+++ b/addon/pods/components/rui-select/component.js
@@ -7,16 +7,22 @@ export default Ember.Component.extend({
   // http://emberjs.jsbin.com/fotuqa
   layout: layout,
   tagName: 'span',
+
   // possible passed-in values with their defaults:
   content: null,
   prompt: null,
   optionValuePath: 'id',
   optionLabelPath: 'title',
+  selection: null,
   action: Ember.K, // action to fire on change
 
-  // shadow the passed-in `selection` to avoid
-  // leaking changes to it via a 2-way binding
-  _selection: Ember.computed.reads('selection'),
+  // create id'ed object from model value
+  // to easily compare and simultaniously update
+  // model property directly
+  // only necessary on initialization
+  selectedOption: Ember.computed('selection', function(){
+    return { id: this.get('selection') }
+  }),
 
   didInitAttrs() {
     this._super(...arguments);
@@ -35,17 +41,12 @@ export default Ember.Component.extend({
       const hasPrompt = !!this.get('prompt');
       const contentIndex = hasPrompt ? selectedIndex - 1 : selectedIndex;
 
+      // Return just a single string or integer value via the mut helper
       const selection = content[contentIndex];
-
-      // set the local, shadowed selection to avoid leaking
-      // changes to `selection` out via 2-way binding
-      this.set('_selection', selection);
-      const changeCallback = this.get('action');
-
-      // Return just a single string or integer value even if an object is used
       const optionValuePath = this.get('optionValuePath');
       const selectionValue = selection[optionValuePath];
 
+      const changeCallback = this.get('action');
       changeCallback(selectionValue);
     }
   }

--- a/addon/pods/components/rui-select/component.js
+++ b/addon/pods/components/rui-select/component.js
@@ -21,7 +21,7 @@ export default Ember.Component.extend({
   // model property directly
   // only necessary on initialization
   selectedOption: Ember.computed('selection', function(){
-    return { id: this.get('selection') }
+    return { id: this.get('selection') };
   }),
 
   didInitAttrs() {

--- a/addon/pods/components/rui-select/template.hbs
+++ b/addon/pods/components/rui-select/template.hbs
@@ -6,8 +6,9 @@
   {{/if}}
 
   {{#each content key="@identity" as |item|}}
-    <option value="{{read-path item optionValuePath}}" selected={{is-equal item selection}}>
+    <option value="{{read-path item optionValuePath}}" selected={{is-equal item.id selectedOption.id}}>
       {{read-path item optionLabelPath}}
      </option>
+
   {{/each}}
 </select>

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -33,3 +33,7 @@ $text-muted:                 $rui-text-color-muted !default;
 // This may get fixed at some point when bs4 stablizes
 $card-border-width:          1px;
 $card-border-radius-inner:   .25rem;
+
+//These are defined in bootstrap but will currently not resolve
+$border-radius-base: 3px;
+$font-size-sm: .85rem;


### PR DESCRIPTION
- Select now always expects an array of objects with value and id
- Select always returns just the selected id as value so it can be directly bound to a model attribute

1. Pull down branch and fire up `ember s`
2. Go to http://localhost:4210/components/#select-basic-example (dummy app example)
3. Changing drop down select should print id below select box. (actions up)
<img width="487" alt="dummy" src="https://cloud.githubusercontent.com/assets/2149063/13756324/a5b6857a-e9dc-11e5-94e0-a6241a92f64c.png">
4. Open ember console and click on `application` controller in the view tree tab. (make sure to make an initial selection so attribute shows console).
5. Manually change the value of `mySelectedProp` to 1, 2, or 3.  The select box should update to display new property value in the front end.
<img width="1131" alt="dummy" src="https://cloud.githubusercontent.com/assets/2149063/13756705/5fff5d66-e9de-11e5-90d4-d0f04cb93c41.png">


