### PR TITLE
Bug: Fix CORS Header Issues

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-cli-revelation-ui",
   "dependencies": {
-    "ember": "2.3.0",
+    "ember": "2.5.1",
     "ember-cli-shims": "0.1.0",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",
@@ -9,7 +9,7 @@
     "loader.js": "^3.5.0"
   },
   "resolutions": {
-    "ember": "2.3.0"
+    "ember": "2.5.1"
   },
   "devDependencies": {
     "tether": "~1.1.1",

--- a/index.js
+++ b/index.js
@@ -34,5 +34,19 @@ module.exports = {
   // Automatically rebuilds on change
   isDevelopingAddon: function() {
     return true;
+  },
+
+  /**
+    This code is taken from ember-cli-cors, but the way the addon loads, it
+    cannot be loaded itself without being overwritten.  If this needs to be
+    updated, reference:
+
+    https://github.com/diploidgenomics/ember-cli-cors/blob/master/index.js
+  **/
+  serverMiddleware: function(config) {
+    config.app.use(function(req, res, next) {
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      next();
+    });
   }
 };

--- a/package.json
+++ b/package.json
@@ -52,6 +52,11 @@
     "ember-cli-babel": "^5.1.5"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "before": [
+      "serve-files-middleware",
+      "history-support-middleware",
+      "proxy-server-middleware"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
     "ember-ajax": "0.7.1",
-    "ember-cli": "2.3.0-beta.2",
+    "ember-cli": "2.5.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-autoprefixer": "0.4.1",
     "ember-cli-content-security-policy": "0.4.0",
@@ -35,7 +35,7 @@
     "ember-cli-sass": "4.1.0",
     "ember-cli-sri": "^2.0.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.3.0",
+    "ember-data": "^2.5.2",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",


### PR DESCRIPTION
### What does this PR do?

The way our current ember apps are loaded, they have a different port for the actual app and the resources.  That creates CORS errors.  This PR adds a little code to set the header 'Access-Control-Allow-Origin' on all responses that are made to these resources. 

This also upgrades ember, ember-cli, and ember-data to the latest versions.

### How to QA?

- [ ] In this project, run `npm install` and then 'npm link'
- [ ] In [Revelation Frontend Admin](https://invent.focusvision.com/Portland/revelation-frontend-admin),
    - [ ] NOMBOM
- [ ] run `npm link ember-cli-revelation-ui` and then start up the app.  Make sure that Admin is on [this branch](https://invent.focusvision.com/Portland/revelation-frontend-admin/tree/bug/km/fix-cors)
- [ ] Go to the ember admin and verify that the icons on the vertical nav are present.  Hard reload to make sure that cached icons aren't displaying.
- [ ] In [Revelation Frontend Participant](https://invent.focusvision.com/Portland/revelation-frontend-participant), run `npm link ember-cli-revelation-ui` and then start up the app.
- [ ] Go to the [ember participant](http://localhost:3000/cli/ep/) and verify that the icons on the vertical nav are present.  Hard reload to make sure that cached icons aren't displaying.

