### PR TITLE
Add common Revelation style files

### DIFF
--- a/addon/pods/components/rui-error-template/component.js
+++ b/addon/pods/components/rui-error-template/component.js
@@ -2,7 +2,7 @@ import Ember from 'ember'
 import layout from './template'
 
 export default Ember.Component.extend({
-  classNames: ['error-template'],
+  classNames: ['rui-error-template'],
   layout,
 
   actions: {

--- a/addon/pods/components/rui-error-template/component.js
+++ b/addon/pods/components/rui-error-template/component.js
@@ -1,0 +1,21 @@
+import Ember from 'ember'
+import layout from './template'
+
+export default Ember.Component.extend({
+  classNames: ['error-template'],
+  layout,
+
+  actions: {
+    back(event){
+      event.preventDefault()
+
+      /**
+      * For now, since all this is managed by rails app,
+      * We have to use window.location to handle navigating
+      * to root then last visited project or login if unauthenticated
+      **/
+
+      return window.location.replace(window.location.origin)
+    }
+  }
+})

--- a/addon/pods/components/rui-error-template/template.hbs
+++ b/addon/pods/components/rui-error-template/template.hbs
@@ -1,0 +1,18 @@
+<div class='rui-header'>
+  <div class='rui-header-nav-group'>
+  <a href='#' onclick={{action 'back'}} class='btn btn-secondary'>
+      {{rui-icon name='arrow-left'}}
+    </a>
+  </div>
+</div>
+
+<div class='error-template-content'>
+  <div class="error-template-message">
+    <div class='error-template-status'>
+      {{status}}
+    </div>
+    <div class="error-template-tagline">
+      {{tagline}}
+    </div>
+  </div>
+</div>

--- a/addon/pods/components/rui-error-template/template.hbs
+++ b/addon/pods/components/rui-error-template/template.hbs
@@ -6,12 +6,12 @@
   </div>
 </div>
 
-<div class='error-template-content'>
-  <div class="error-template-message">
-    <div class='error-template-status'>
+<div class='rui-error-template-content'>
+  <div class="rui-error-template-message">
+    <div class='rui-error-template-status'>
       {{status}}
     </div>
-    <div class="error-template-tagline">
+    <div class="rui-error-template-tagline">
       {{tagline}}
     </div>
   </div>

--- a/addon/pods/components/rui-flash/component.js
+++ b/addon/pods/components/rui-flash/component.js
@@ -1,0 +1,22 @@
+import Ember from 'ember'
+import layout from './template'
+
+/* Basic Usage
+
+* this.get('flashMessages').success('A success message!');
+* this.get('flashMessages').danger('A danger message!');
+* this.get('flashMessages').info('A info message!');
+* this.get('flashMessages').warning('A warning message!');
+
+*/
+
+const {
+  Component,
+  inject
+} = Ember
+
+export default Component.extend({
+  layout,
+  flashMessages: inject.service(),
+  classNames: ['ember-cli-flash']
+})

--- a/addon/pods/components/rui-flash/component.js
+++ b/addon/pods/components/rui-flash/component.js
@@ -18,5 +18,5 @@ const {
 export default Component.extend({
   layout,
   flashMessages: inject.service(),
-  classNames: ['ember-cli-flash']
+  classNames: ['rui-flash']
 })

--- a/addon/pods/components/rui-flash/template.hbs
+++ b/addon/pods/components/rui-flash/template.hbs
@@ -1,0 +1,3 @@
+{{#each flashMessages.queue as |flash|}}
+  {{flash-message flash=flash}}
+{{/each}}

--- a/addon/pods/components/rui-toggle-input/component.js
+++ b/addon/pods/components/rui-toggle-input/component.js
@@ -1,0 +1,11 @@
+import Ember from 'ember'
+import layout from './template'
+
+const { Component } = Ember
+
+export default Component.extend({
+  layout,
+  tagName: 'span',
+  classNames: ['toggle-input'],
+  classNameBindings: ['checked:toggle-input-on:toggle-input-off']
+})

--- a/addon/pods/components/rui-toggle-input/template.hbs
+++ b/addon/pods/components/rui-toggle-input/template.hbs
@@ -1,0 +1,5 @@
+{{input
+checked=checked
+id=for
+type="checkbox"}}
+<label for={{for}}></label>

--- a/addon/pods/components/rui-validatable-input/component.js
+++ b/addon/pods/components/rui-validatable-input/component.js
@@ -1,0 +1,42 @@
+import Ember from 'ember'
+import layout from './template'
+
+const {
+  Component,
+  computed,
+  defineProperty
+} = Ember
+
+export default Component.extend({
+  classNameBindings: ['showErrorClass:has-error', 'isValid:has-success'],
+  classNames: ['rui-validatable-input'],
+  layout,
+  model: null,
+  placeholder: '',
+  type: 'text',
+  validation: null,
+  value: null,
+  valuePath: '',
+
+  init() {
+    this._super(...arguments)
+    const valuePath = this.get('valuePath')
+    defineProperty(this, 'validation', computed.oneWay(`model.validations.attrs.${valuePath}`))
+    defineProperty(this, 'value', computed.alias(`model.${valuePath}`))
+  },
+
+  didChange: computed('value', 'model.hasDirtyAttributes', function() {
+    let attrsChanged = this.get('model') ? this.get('model').changedAttributes() : []
+    return this.get('valuePath') in attrsChanged
+  }),
+  didValidate: computed.oneWay('targetObject.didValidate'),
+  hasContent: computed.notEmpty('value'),
+  isInvalid: computed.oneWay('validation.isInvalid'),
+  isValid: computed.and('didChange', 'hasContent', 'validation.isValid', 'notValidating'),
+  notValidating: computed.not('validation.isValidating'),
+  showErrorClass: computed.and('notValidating', 'showMessage', 'validation'),
+  showMessage: computed('validation.isDirty', 'isInvalid', 'didValidate', function() {
+    return (this.get('validation.isDirty') || this.get('didValidate')) && this.get('isInvalid')
+  })
+
+})

--- a/addon/pods/components/rui-validatable-input/template.hbs
+++ b/addon/pods/components/rui-validatable-input/template.hbs
@@ -1,0 +1,19 @@
+{{input
+type=type
+value=value
+placeholder=placeholder
+class='form-control'
+name=valuePath}}
+
+{{#if isValid}}
+  <p class='input-valid'>
+    Looks good!
+  </p>
+{{/if}}
+
+{{#if showMessage}}
+  <p class='input-error'>
+    {{v-get model valuePath 'message'}}
+  </p>
+{{/if}}
+

--- a/addon/pods/components/rui-validatable-textarea/component.js
+++ b/addon/pods/components/rui-validatable-textarea/component.js
@@ -1,0 +1,41 @@
+import Ember from 'ember'
+import layout from './template'
+
+const {
+  Component,
+  computed,
+  defineProperty
+} = Ember
+
+export default Component.extend({
+  classNameBindings: ['showErrorClass:has-error', 'isValid:has-success'],
+  classNames: ['rui-validatable-textarea'],
+  layout,
+  model: null,
+  placeholder: '',
+  type: 'text',
+  validation: null,
+  value: null,
+  valuePath: '',
+
+  init() {
+    this._super(...arguments)
+    const valuePath = this.get('valuePath')
+    defineProperty(this, 'validation', computed.oneWay(`model.validations.attrs.${valuePath}`))
+    defineProperty(this, 'value', computed.alias(`model.${valuePath}`))
+  },
+
+  didChange: computed('value', 'model.hasDirtyAttributes', function() {
+    const attrsChanged = this.get('model') ? this.get('model').changedAttributes() : []
+    return this.get('valuePath') in attrsChanged
+  }),
+  didValidate: computed.oneWay('targetObject.didValidate'),
+  hasContent: computed.notEmpty('value'),
+  isInvalid: computed.oneWay('validation.isInvalid'),
+  isValid: computed.and('didChange', 'hasContent', 'validation.isValid', 'notValidating'),
+  notValidating: computed.not('validation.isValidating'),
+  showErrorClass: computed.and('notValidating', 'showMessage', 'validation'),
+  showMessage: computed('validation.isDirty', 'isInvalid', 'didValidate', function() {
+    return (this.get('validation.isDirty') || this.get('didValidate')) && this.get('isInvalid')
+  })
+})

--- a/addon/pods/components/rui-validatable-textarea/template.hbs
+++ b/addon/pods/components/rui-validatable-textarea/template.hbs
@@ -1,0 +1,18 @@
+{{textarea
+value=value
+placeholder=placeholder
+class='form-control'
+name=valuePath}}
+
+{{#if isValid}}
+  <p class='input-valid'>
+    Looks Good!
+  </p>
+{{/if}}
+
+{{#if showMessage}}
+  <p class='input-error'>
+    {{v-get model valuePath 'message'}}
+  </p>
+{{/if}}
+

--- a/app/pods/components/rui-error-template/component.js
+++ b/app/pods/components/rui-error-template/component.js
@@ -1,0 +1,2 @@
+export { default }
+  from 'ember-cli-revelation-ui/pods/components/rui-error-template/component'

--- a/app/pods/components/rui-flash/component.js
+++ b/app/pods/components/rui-flash/component.js
@@ -1,0 +1,2 @@
+export { default }
+  from 'ember-cli-revelation-ui/pods/components/rui-flash/component'

--- a/app/pods/components/rui-toggle-input/component.js
+++ b/app/pods/components/rui-toggle-input/component.js
@@ -1,0 +1,2 @@
+export { default }
+  from 'ember-cli-revelation-ui/pods/components/rui-toggle-input/component'

--- a/app/pods/components/rui-validatable-input/component.js
+++ b/app/pods/components/rui-validatable-input/component.js
@@ -1,0 +1,2 @@
+export { default }
+  from 'ember-cli-revelation-ui/pods/components/rui-validatable-input/component'

--- a/app/pods/components/rui-validatable-textarea/component.js
+++ b/app/pods/components/rui-validatable-textarea/component.js
@@ -1,0 +1,2 @@
+export { default }
+  from 'ember-cli-revelation-ui/pods/components/rui-validatable-textarea/component'

--- a/app/styles/_rui-base.sass
+++ b/app/styles/_rui-base.sass
@@ -24,4 +24,4 @@
 @import components/rui-forms
 @import components/rui-large-spinner
 @import components/title-header
-@import components/validatable-input
+@import components/rui-validatable-input

--- a/app/styles/_rui-base.sass
+++ b/app/styles/_rui-base.sass
@@ -10,7 +10,7 @@
 @import modules/mixins
 // Components
 @import components/layout
-@import components/ember-cli-flash
+@import components/rui-flash
 @import components/error-template
 @import components/forms
 @import components/nav-vertical

--- a/app/styles/_rui-base.sass
+++ b/app/styles/_rui-base.sass
@@ -25,3 +25,4 @@
 @import components/rui-large-spinner
 @import components/title-header
 @import components/rui-validatable-input
+@import components/rui-toggle-input

--- a/app/styles/_rui-base.sass
+++ b/app/styles/_rui-base.sass
@@ -9,6 +9,11 @@
 @import components/rui-extend
 @import modules/mixins
 // Components
+@import components/layout
+@import components/ember-cli-flash
+@import components/error-template
+@import components/forms
+@import components/nav-vertical
 @import components/rui-avatar
 @import components/rui-buttons
 @import components/rui-dropdowns
@@ -18,3 +23,5 @@
 @import components/rui-typography
 @import components/rui-forms
 @import components/rui-large-spinner
+@import components/title-header
+@import components/validatable-input

--- a/app/styles/_rui-base.sass
+++ b/app/styles/_rui-base.sass
@@ -11,7 +11,7 @@
 // Components
 @import components/layout
 @import components/rui-flash
-@import components/error-template
+@import components/rui-error-template
 @import components/forms
 @import components/nav-vertical
 @import components/rui-avatar

--- a/app/styles/components/_ember-cli-flash.sass
+++ b/app/styles/components/_ember-cli-flash.sass
@@ -1,0 +1,38 @@
+$z-index-flash: 1000
+
+@mixin close-icon
+  content: '×'
+  text-align: center
+  color: rgba(0,0,0,.15)
+  font-size: 2rem
+  line-height: 1
+
+.ember-cli-flash
+  position: fixed
+  top: 0
+  right: 0
+  left: 0
+  z-index: $z-index-flash
+  pointer-events: none
+  .alert
+    position: relative
+    max-width: 600px
+    pointer-events: auto // Reset so alerts are clickable
+    margin: $spacer auto 0
+    border-bottom-width: 3px
+    padding-right: 43px
+    &::after
+      @include close-icon()
+      position: absolute
+      right: $spacer
+      top: .8rem
+    &:hover
+      cursor: pointer
+      &::after
+        color: rgba(0,0,0,.3)
+
+@include media-breakpoint-down(sm)
+  .ember-cli-flash
+    .alert
+      max-width: 100%
+      margin: $spacer $spacer 0

--- a/app/styles/components/_error-template.sass
+++ b/app/styles/components/_error-template.sass
@@ -1,0 +1,31 @@
+.error-template-content
+  align-items: center
+  bottom: 0
+  display: flex
+  justify-content: center
+  left: 0
+  position: fixed
+  right: 0
+  top: $rui-header-height
+  text-align: center
+  transform: translate(0, -15%)
+  padding: 0 $spacer*2
+
+.error-template-status
+  font-size: $font-size-base*10
+  color: $rui-text-color-muted
+
+.error-template-tagline
+  font-size: $font-size-lg
+
+.rui-header-nav-group
+  display: flex
+  height: $rui-header-height
+  align-items: center
+
+.error-template
+  .rui-header
+    padding: 0 $spacer
+  .rui-header-nav-group
+    .btn + .btn
+      margin-right: $spacer

--- a/app/styles/components/_forms.sass
+++ b/app/styles/components/_forms.sass
@@ -1,0 +1,37 @@
+.form-body
+  padding: $spacer $spacer $spacer*4
+
+.form-header
+  padding-bottom: $spacer
+  border-bottom: 3px solid $rui-border-color-light
+  text-align: right
+
+.form-options
+  padding-bottom: $spacer
+  padding-top: $spacer
+
+.form-group
+  border-bottom: $border-width solid $rui-border-color-light
+  padding-bottom: $spacer
+  padding-top: $spacer
+  margin-bottom: 0
+  label
+    font-weight: bold
+
+.form-group-contents
+  position: relative
+  color: $rui-text-color-muted
+
+.form-group-toggle
+  .form-group-contents
+    padding-right: $spacer*7
+  .form-group-input
+    position: absolute
+    right: 0
+    top: 0
+
+.form-control-md
+  &,
+  select,
+  input
+    width: $spacer*14

--- a/app/styles/components/_layout.sass
+++ b/app/styles/components/_layout.sass
@@ -1,0 +1,234 @@
+$rui-header-height: 4.28572rem //~60px @ 14
+// $rui-footer-height: 3.57143rem //~50px @ 14
+$rui-footer-height: 36px; // 3.57143rem //~50px @ 14 // Retrofit height
+$rui-sidebar-left-width: 240px
+
+$z-footer: 510
+$z-sidebar: 500
+$z-clickblock: 490
+$z-header: 510
+
+// Overlay that captures clicks to collapse menu when open
+.rui-clickblock
+  display: none
+  position: fixed
+  left: 0
+  top: 0
+  z-index: $z-clickblock
+  height: 100%
+  width: 100%
+  background: rgba(0,0,0,.3)
+  touch-action: manipulation
+  cursor: pointer
+
+
+// Header layout defaults (Fixed)
+.rui-header
+  position: fixed
+  top: 0
+  right: 0
+  left: 0
+  height: $rui-header-height
+  z-index: $z-header
+  background: $rui-nav-bg
+  border-bottom: $border-width solid $rui-border-color-light
+
+// Toggles
+.rui-header-menu-block
+  transition: transform .2s cubic-bezier(.16, .68, .43, .99)
+  transform: translate3d(-54px, 0, 0)
+  .unfix-menu &
+    transform: translate3d(0, 0, 0)
+
+// Expand/Collapses sidebar only when unfixed
+// Hide when fixed
+.rui-show-menu-toggle
+  display: flex
+  height: $rui-header-height
+  align-items: center
+  .rui-show-menu-toggle-btn
+    font-size: 28px
+    line-height: 1
+    padding-right: $spacer
+    padding-left: $spacer
+    &.active,
+    &:active,
+    &:focus
+      outline: 0
+    &.btn
+      color: $rui-text-color
+
+@include media-breakpoint-down(sm)
+  .rui-header-menu-block
+    transform: translate3d(0, 0, 0)
+
+// Fixes/unfixes sidebar
+// Hide when @media(sm)
+.rui-fix-menu-toggle
+  height: $rui-footer-height
+  display: table-cell
+  vertical-align: middle
+  border-right: $border-width solid $rui-border-color-light
+  > .btn
+    color: $rui-text-color
+    padding-left: 1rem
+    padding-right: 1rem
+    line-height: 1
+    &.active,
+    &:active,
+    &:focus
+      outline: 0
+
+// Unfix Menu @media(sm)
+// collapse margin-left
+@include media-breakpoint-down(sm)
+  // Show menu toggle regardless of state
+  .rui-show-menu-toggle
+    display: flex !important
+
+  // Hide fix menu toggle regardless of state
+  .rui-fix-menu-toggle
+    display: none
+
+// Main content region
+// Left margin when fixed, none when fixed
+.rui-main
+  margin-top: $rui-header-height
+  margin-left: $rui-sidebar-left-width
+  .unfix-menu &
+    margin-left: 0
+
+// Unfix Menu @media(sm)
+// collapse margin-left
+@include media-breakpoint-down(sm)
+  .rui-main
+    margin-left: 0
+
+// Sidebar layout defaults
+.rui-sidebar-left
+  position: fixed
+  top: $rui-header-height
+  bottom: 0
+  left: 0
+  z-index: $z-sidebar
+  width: $rui-sidebar-left-width
+  background: $rui-nav-bg
+  border-right: $border-width solid $rui-border-color-light
+  // Sidebar unfixed
+  // Flush top and off-canvas by default
+  .unfix-menu &
+    top: 0
+    left: -$rui-sidebar-left-width
+
+// Unfix Menu @media(sm)
+// Flush top and off-canvas by default
+@include media-breakpoint-down(sm)
+  .rui-sidebar-left
+    top: 0
+    left: -$rui-sidebar-left-width
+
+// Powered by Focusvision logo
+.rui-sidebar-footer-logo
+  position: fixed
+  background: #e4e4e4
+  z-index: $z-sidebar + 10
+  left: 0
+  bottom: 0
+  width: $rui-sidebar-left-width - 1px
+  padding: $spacer*1.7 0 $spacer
+  text-align: center
+  background: -moz-linear-gradient(top, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 25%, rgba(255,255,255,1) 100%) /* FF3.6-15 */
+  background: -webkit-linear-gradient(top, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 25%,rgba(255,255,255,1) 100%) /* Chrome10-25,Safari5.1-6 */
+  background: linear-gradient(to bottom, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 25%,rgba(255,255,255,1) 100%) /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+  .unfix-menu &,
+  .show-menu &,
+  .unfix-menu.show-menu &
+    left: -$rui-sidebar-left-width
+  img
+    height: 12px
+
+// Footer layout defaults
+.rui-footer
+  position: fixed
+  bottom: 0
+  right: 0
+  left: $rui-sidebar-left-width
+  height: $rui-footer-height
+  z-index: $z-footer
+  background: $rui-nav-bg
+  border-top: $border-width solid $rui-border-color-light
+  // Footer unfixed
+  // Flush left
+  .unfix-menu &
+    left: 0
+
+// Unfix Menu @media(sm)
+// fix to bottom of sidebar, position and width
+@include media-breakpoint-down(sm)
+  .rui-footer
+    z-index: $z-footer
+    left: -$rui-sidebar-left-width
+    right: auto
+    width: $rui-sidebar-left-width - 1px
+    .unfix-menu &,
+    .show-menu &,
+    .unfix-menu.show-menu &
+      z-index: $z-footer !important
+      left: -$rui-sidebar-left-width
+
+// Transition for all objects that animate together
+.rui-header,
+.rui-main,
+.rui-sidebar-left,
+.rui-footer
+  transition: transform .2s cubic-bezier(.16, .68, .43, .99)
+
+// Shows menu when unfixed
+.unfix-menu.show-menu
+  overflow-x: hidden // Disable scrolling on x-axis
+  .rui-header,
+  .rui-main,
+  .rui-sidebar-left,
+  .rui-footer
+    transform: translate3d($rui-sidebar-left-width, 0, 0) // Move all elements right
+  .rui-header,
+  .rui-footer
+    z-index: $z-clickblock - 5 // Put the footer behind the clickblock when not @media(sm)
+  .rui-sidebar-left
+    border-right-color: transparent
+  .rui-clickblock
+    display: block
+    animation: fadeIn .2s  // Fade in clickblock, animation required to toggle display and fade in
+
+
+
+// Unfix Menu @media(sm)
+// Should expand menu as if unfixed
+@include media-breakpoint-down(sm)
+  .show-menu
+    overflow-x: hidden
+    .rui-header,
+    .rui-main,
+    .rui-sidebar-left,
+    .rui-footer
+      transform: translate3d($rui-sidebar-left-width, 0, 0)
+    .rui-header
+      z-index: $z-clickblock - 5 // Put the footer behind the clickblock when not @media(sm)
+      // filter: blur(5px) grayscale(.7)
+    .rui-sidebar-left
+      border-right-color: transparent
+    .rui-main
+      // filter: blur(5px) grayscale(.7)
+    .rui-clickblock
+      display: block
+      animation: fadeIn .2s
+
+// Clickblock fadein animation
+@keyframes fadeIn
+  from {opacity: 0}
+  to {opacity: 1}
+
+// @include media-breakpoint-down(xl)
+// @include media-breakpoint-down(lg)
+// @include media-breakpoint-down(md)
+// @include media-breakpoint-down(sm)

--- a/app/styles/components/_nav-vertical.sass
+++ b/app/styles/components/_nav-vertical.sass
@@ -1,0 +1,96 @@
+.nav-vertical-scroll
+  overflow-y: auto
+  position: fixed
+  top: $rui-header-height * 2
+  bottom: $rui-footer-height
+  width: inherit
+  padding-bottom: 30px
+
+.unfix-menu,
+.show-menu
+  .nav-vertical-scroll
+    top: $rui-header-height
+
+.nav-vertical-group + .nav-vertical-group
+  margin-top: 3rem
+
+.nav-vertical-title
+  font-size: $font-size-sm
+  padding: $spacer/2 $spacer
+  text-transform: uppercase
+
+.nav-vertical-menu
+  @extend .list-unstyled
+  font-weight: bold
+
+.nav-vertical-item
+  i
+    position: absolute
+    left: $spacer
+    top: .75rem
+    width: 1rem
+    text-align: center
+  a
+    display: block
+    position: relative
+    border-left: .25rem solid transparent
+    padding: $spacer/2 $spacer $spacer/2 (2.75 * $spacer)
+    color: $rui-text-color
+    &:hover,
+    &:active,
+    &:focus
+      text-decoration: none
+    &.active
+      border-left: .25rem solid $brand-primary
+      background: $gray-lightest
+  .nav-vertical-menu
+    a
+      font-weight: normal
+      font-size: $font-size-sm
+      &.active
+        border-left-color: transparent
+        color: $brand-primary
+        background: transparent
+
+.nav-vertical-item-expandable
+  > a + button
+    @extend .btn-unstyled
+    position: absolute
+    right: 0
+    margin-top: -2.0625 * $spacer
+    &::after
+      display: block
+      width: 3rem
+      padding-top: $spacer/2-.4
+      padding-bottom: $spacer/2-.4
+      border-left: 1px solid $rui-border-color-light
+      text-align: center
+      color: $rui-text-color-light
+      @extend .angle-down
+      &.active
+        @extend .angle-up
+
+.nav-vertical-tertiary-item
+  a, button
+    display: block
+    position: relative
+    border-left: .25rem solid transparent
+    padding: $spacer/3 $spacer
+    color: $rui-text-color-muted
+    font-size: $font-size-sm
+    &:hover,
+    &:active,
+    &:focus
+      text-decoration: none
+      color: $rui-text-color
+  // NOTE: Extending btn-unstyled breaks Zendesk interoperability
+  button
+    border: 0 none
+    border-left: .25rem solid transparent
+    background: transparent
+    outline: 0
+    display: block
+
+// NOTE: Hide the default Zendesk web widget button
+.zEWidget-launcher
+  display: none

--- a/app/styles/components/_nav-vertical.sass
+++ b/app/styles/components/_nav-vertical.sass
@@ -65,7 +65,7 @@
       padding-bottom: $spacer/2-.4
       border-left: 1px solid $rui-border-color-light
       text-align: center
-      color: $rui-text-color-light
+      color: $rui-text-color-muted
       @extend .angle-down
       &.active
         @extend .angle-up

--- a/app/styles/components/_rui-error-template.sass
+++ b/app/styles/components/_rui-error-template.sass
@@ -1,4 +1,4 @@
-.error-template-content
+.rui-error-template-content
   align-items: center
   bottom: 0
   display: flex
@@ -11,11 +11,11 @@
   transform: translate(0, -15%)
   padding: 0 $spacer*2
 
-.error-template-status
+.rui-error-template-status
   font-size: $font-size-base*10
   color: $rui-text-color-muted
 
-.error-template-tagline
+.rui-error-template-tagline
   font-size: $font-size-lg
 
 .rui-header-nav-group
@@ -23,7 +23,7 @@
   height: $rui-header-height
   align-items: center
 
-.error-template
+.rui-error-template
   .rui-header
     padding: 0 $spacer
   .rui-header-nav-group

--- a/app/styles/components/_rui-flash.sass
+++ b/app/styles/components/_rui-flash.sass
@@ -7,7 +7,7 @@ $z-index-flash: 1000
   font-size: 2rem
   line-height: 1
 
-.ember-cli-flash
+.rui-flash
   position: fixed
   top: 0
   right: 0
@@ -32,7 +32,7 @@ $z-index-flash: 1000
         color: rgba(0,0,0,.3)
 
 @include media-breakpoint-down(sm)
-  .ember-cli-flash
+  .rui-flash
     .alert
       max-width: 100%
       margin: $spacer $spacer 0

--- a/app/styles/components/_rui-toggle-input.sass
+++ b/app/styles/components/_rui-toggle-input.sass
@@ -1,0 +1,88 @@
+// Toggle on/off labels
+$show-toggle-input-labels: true
+
+$toggle-btn-height: 26px
+$toggle-btn-width: $toggle-btn-height
+$toggle-btn-border-color: $rui-border-color-dark // remove
+$toggle-btn-bg: $gray-lightest
+$toggle-btn-radius: 50px
+
+$toggle-track-padding: 2px
+$toggle-track-height: $toggle-btn-height + ($toggle-track-padding*2)
+$toggle-track-width: $toggle-btn-width*1.7
+$toggle-track-bg-on: $brand-primary
+$toggle-track-bg-off: $rui-border-color-light
+
+$toggle-transition-speed: .3s
+
+.toggle-input
+  position: relative
+  @if $show-toggle-input-labels == true
+    padding: 0px 22px 0 24px
+  display: inline-block
+
+  @if $show-toggle-input-labels == true
+    // On/Off Labels
+    &::after,
+    &::before
+      color: $rui-text-color-muted
+      position: absolute
+      top: 3px
+      font-size: $font-size-sm
+      opacity: .3
+    &::after
+      right: 0
+      content: 'on'
+    &::before
+      left: 0
+      content: 'off'
+    &.toggle-input-on::after,
+    &.toggle-input-off::before
+      opacity: 1
+
+  // Hidden checkbox
+  input
+    position: absolute
+    left: -9999px
+    visibility: hidden
+
+  // Track
+  label
+    background-color: $toggle-track-bg-off
+    border-radius: $toggle-btn-radius
+    cursor: pointer
+    display: inline-block
+    height: $toggle-track-height
+    margin-bottom: 0
+    outline: none
+    position: relative
+    transition: background $toggle-transition-speed
+    user-select: none
+    width: $toggle-track-width
+    box-shadow: inset 0 1px 3px 0 rgba(0,0,0,.2)
+    // Button
+    &::after
+      background-color: $toggle-btn-bg
+      border-radius: $toggle-btn-radius
+      content: ' '
+      display: block
+      position: absolute
+      left: 0px
+      top: $toggle-track-padding
+      margin-left: $toggle-track-padding
+      width: $toggle-btn-width
+      height: $toggle-btn-height
+      transition: margin 0.3s, border-color 0.3s
+      box-shadow: 0 1px 1px 0 rgba(0,0,0,.2), inset 0 1px 0 0 #fff
+
+  // On State
+  input:checked
+    + label
+      background-color: $toggle-track-bg-on
+      &:after
+        margin-left: $toggle-track-width - $toggle-btn-width - $toggle-track-padding
+
+  // Hover State
+  label:hover
+    &:after
+      box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.3), inset 0 1px 0 0 #fff

--- a/app/styles/components/_rui-validatable-input.sass
+++ b/app/styles/components/_rui-validatable-input.sass
@@ -17,6 +17,6 @@
   color: $brand-success
 
 // Textarea
-.validatable-textarea
+.rui-validatable-textarea
   textarea
     min-height: 150px

--- a/app/styles/components/_title-header.sass
+++ b/app/styles/components/_title-header.sass
@@ -1,0 +1,11 @@
+.title-header
+  padding: 1.25rem 2rem
+
+.title-header h1
+  font-size: 1.25rem
+  font-weight: bold
+
+.title-header h2
+  font-size: 1rem
+  font-weight: normal
+  line-height: 1.5

--- a/app/styles/components/_validatable-input.sass
+++ b/app/styles/components/_validatable-input.sass
@@ -1,0 +1,22 @@
+// Input state
+.has-success
+  .form-control
+    border-color: $brand-success
+.has-error
+  .form-control
+    border-color: $brand-danger
+
+// Error Messages
+.input-error,
+.input-valid
+  margin: 10px 0 0
+  font-style: italic
+.input-error
+  color: $brand-danger
+.input-valid
+  color: $brand-success
+
+// Textarea
+.validatable-textarea
+  textarea
+    min-height: 150px

--- a/blueprints/ember-cli-revelation-ui/index.js
+++ b/blueprints/ember-cli-revelation-ui/index.js
@@ -10,7 +10,8 @@ module.exports = {
     ]).then(function(){
       return self.addPackagesToProject([
         { name: 'ember-cli-sass',           target: '4.1.0' },
-        { name: 'ember-cli-autoprefixer',   target: '0.4.1' }
+        { name: 'ember-cli-autoprefixer',   target: '0.4.1' },
+        { name: 'ember-cli-flash',          target: '1.3.15' }
       ]);
     });
   }

--- a/blueprints/ember-cli-revelation-ui/index.js
+++ b/blueprints/ember-cli-revelation-ui/index.js
@@ -11,7 +11,8 @@ module.exports = {
       return self.addPackagesToProject([
         { name: 'ember-cli-sass',           target: '4.1.0' },
         { name: 'ember-cli-autoprefixer',   target: '0.4.1' },
-        { name: 'ember-cli-flash',          target: '1.3.15' }
+        { name: 'ember-cli-flash',          target: '1.3.15' },
+        { name: 'ember-cp-validations',     target: '2.7.1' }
       ]);
     });
   }

--- a/bower.json
+++ b/bower.json
@@ -6,14 +6,14 @@
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",
     "jquery": "^2.1.4",
-    "loader.js": "^3.5.0"
+    "loader.js": "^3.5.0",
+    "font-awesome": "~4.4.0"
   },
   "resolutions": {
     "ember": "2.5.1"
   },
   "devDependencies": {
     "tether": "~1.1.1",
-    "bootstrap": "v4-dev",
-    "font-awesome": "~4.4.0"
+    "bootstrap": "v4-dev"
   }
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,10 +1,22 @@
-'use strict';
+/* jshint node: true */
+'use strict'
 
 module.exports = function(/* environment, appConfig */) {
   var ENV = {
-    modulePrefix: 'dummy',
-    podModulePrefix: 'dummy/pods'
-  };
+    modulePrefix: 'ember-cli-revelation-ui',
+    podModulePrefix: 'ember-cli-revelation-ui/pods',
 
-  return ENV;
-};
+    flashMessageDefaults: {
+      extendedTimeout: 0,
+      preventDuplicates: true,
+      priority: 200,
+      showProgress: false,
+      sticky: false,
+      timeout: 3000,
+      type: 'info',
+      types: [ 'success', 'warning', 'danger', 'info' ]
+    }
+  }
+
+  return ENV
+}

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "ember-cli-flash": "1.3.15",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-sass": "4.1.0",
-    "ember-cli-babel": "^5.1.5"
+    "ember-cli-babel": "^5.1.5",
+    "ember-cp-validations": "2.7.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "ember-ajax": "0.7.1",
     "ember-cli": "2.5.0",
     "ember-cli-app-version": "^1.0.0",
-    "ember-cli-autoprefixer": "0.4.1",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
@@ -47,6 +46,9 @@
     "ember-addon"
   ],
   "dependencies": {
+    "ember-cli-sass": "4.1.0",
+    "ember-cli-autoprefixer": "0.4.1",
+    "ember-cli-flash": "1.3.15",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-sass": "4.1.0",
     "ember-cli-babel": "^5.1.5"

--- a/tests/helpers/flash-message.js
+++ b/tests/helpers/flash-message.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+import FlashObject from 'ember-cli-flash/flash/object';
+
+const { K } = Ember;
+
+FlashObject.reopen({ init: K });

--- a/tests/integration/components/rui-error-template/component-test.js
+++ b/tests/integration/components/rui-error-template/component-test.js
@@ -1,0 +1,23 @@
+import { moduleForComponent, test } from 'ember-qunit'
+import hbs from 'htmlbars-inline-precompile'
+
+moduleForComponent('rui-error-template', 'Integration | Component | rui error template', {
+  integration: true
+})
+
+test('it renders', function(assert) {
+  this.render(
+    hbs`{{rui-error-template
+      status='500'
+      tagline='There has been an error.'}}`
+  )
+
+  assert.equal(
+    this.$().find('.rui-error-template-status').text().trim(),
+    '500'
+  )
+  assert.equal(
+    this.$().find('.rui-error-template-tagline').text().trim(),
+    'There has been an error.'
+  )
+})

--- a/tests/integration/components/rui-toggle-input/component-test.js
+++ b/tests/integration/components/rui-toggle-input/component-test.js
@@ -1,0 +1,47 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('rui-toggle-input', 'Integration | Component | rui toggle input', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });"
+
+  this.render(hbs`
+    {{rui-toggle-input}}
+  `);
+
+  const component = this.$('.toggle-input')[0];
+  const track = $('label', component);
+  const checkbox = $('input[type=checkbox]', component);
+
+  assert.equal(track.length, 1, 'it renders a label element inside');
+  assert.equal(checkbox.length, 1, 'it renders an input element inside');
+});
+
+test('it toggles on when clicked', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });"
+  this.set('myBoolean', false);
+
+  this.render(hbs`
+    {{rui-toggle-input
+    checked=(mut myBoolean)
+    for='testComponent'}}
+  `);
+
+  const component = this.$('.toggle-input')[0];
+  const label = $('label', component);
+  const checkbox = $('input[type=checkbox]', component);
+
+  assert.equal($(component).hasClass('toggle-input-off'), true, 'class is `.toggle-input-off` initially');
+  assert.equal($(checkbox).is(':checked'), false, 'checkbox is NOT checked initially');
+
+  $(label).click();
+
+  assert.equal($(component).hasClass('toggle-input-on'), true, 'class is `toggle-input-on` when clicked');
+  assert.equal($(checkbox).is(':checked'), true, 'checkbox is checked when clicked');
+
+});

--- a/tests/integration/components/rui-validatable-input/component-test.js
+++ b/tests/integration/components/rui-validatable-input/component-test.js
@@ -1,0 +1,15 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('rui-validatable-input', 'Integration | Component | rui validatable input', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });"
+
+  this.render(hbs`{{rui-validatable-input}}`);
+
+  assert.equal(this.$().text().trim(), '');
+});

--- a/tests/integration/components/rui-validatable-textarea/component-test.js
+++ b/tests/integration/components/rui-validatable-textarea/component-test.js
@@ -1,0 +1,15 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('rui-validatable-textarea', 'Integration | Component | rui validatable textarea', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });"
+
+  this.render(hbs`{{rui-validatable-textarea}}`);
+
+  assert.equal(this.$().text().trim(), '');
+});

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,4 +1,6 @@
 import resolver from './helpers/resolver';
+import './helpers/flash-message';
+
 import {
   setResolver
 } from 'ember-qunit';


### PR DESCRIPTION
Rather than repeating styling, this adds a bunch of common Revelation style for common elements including:

Layout
Flash Messages
Error templates
Form elements
Vertical navbar
Titles
Validatable inputs

Also adds components for: 

Error Endpoint component
Validatable-inputs and textareas
Toggle-inputs
Flash-messages


Needs to be paired with the other PRs in [Participant](https://invent.focusvision.com/Portland/revelation-frontend-participant/pull/51) and [Admin](https://invent.focusvision.com/Portland/revelation-frontend-admin/pull/163) apps.
