### PR TITLE
Make themeable sass variables customizable + update colors to match master

### DIFF
--- a/addon/pods/components/rui-dropdown-trigger/component.js
+++ b/addon/pods/components/rui-dropdown-trigger/component.js
@@ -27,7 +27,15 @@ export default Component.extend({
 
   //Constructors
   classPrefix: 'btn',
-  styles: ['primary', 'secondary', 'success', 'warning', 'danger', 'info', 'link'],
+  styles: [
+    'danger',
+    'info',
+    'link',
+    'primary',
+    'secondary',
+    'success',
+    'warning'
+  ],
 
   // Data Attrs, required by bootstrap
   'data-toggle': 'dropdown',

--- a/addon/pods/components/rui-dropdown-trigger/component.js
+++ b/addon/pods/components/rui-dropdown-trigger/component.js
@@ -9,7 +9,7 @@ export default Ember.Component.extend({
   attributeBindings: [
     'type',
     'data-toggle',
-    'haspopup',
+    'aria-haspopup',
     'aria-expanded',
     'data-test-id'
   ],
@@ -27,7 +27,7 @@ export default Ember.Component.extend({
   'data-toggle': 'dropdown',
 
   // Accessibility
-  haspopup: 'true',
+  'aria-haspopup': 'true',
   'aria-expanded': 'false',
 
   // Computed

--- a/addon/pods/components/rui-dropdown-trigger/component.js
+++ b/addon/pods/components/rui-dropdown-trigger/component.js
@@ -48,20 +48,18 @@ export default Component.extend({
   computedStyle: computed('style', function(){
     // Builds size button class
     // Should not have any btn class by default to allow for custom classing
+    const styles = this.get('styles')
+    let style = this.get('style')
 
-    if (!this.get('style')) {
+    if (!style) {
       return false
     }
 
-    const styles = this.get('styles')
-    const findStyle = this.get('style')
-    const resolvedStyle = findStyle
-
-    if (styles.indexOf(findStyle) === -1) {
-      resolvedStyle = 'secondary'
+    if (styles.indexOf(style) === -1) {
+      style = 'secondary'
       Logger.warn('rui-dropdown-trigger: You specified and unsupported \'style\' property so we\'ve defaulted to the secondary style: choose from \'primary secondary success warning danger info link.\'')
     }
 
-    return 'btn ' + this.get('classPrefix') + '-' + resolvedStyle
+    return 'btn ' + this.get('classPrefix') + '-' + style
   }),
 })

--- a/addon/pods/components/rui-dropdown-trigger/component.js
+++ b/addon/pods/components/rui-dropdown-trigger/component.js
@@ -6,8 +6,13 @@ export default Ember.Component.extend({
   tagName: 'button',
   classNames: ['dropdown-toggle'],
   classNameBindings: ['computedStyle'],
-  attributeBindings: ['type', 'data-toggle', 'haspopup', 'aria-expanded'],
-  id: '',
+  attributeBindings: [
+    'type',
+    'data-toggle',
+    'haspopup',
+    'aria-expanded',
+    'data-test-id'
+  ],
 
   //Defaults
   type: 'button',

--- a/addon/pods/components/rui-dropdown-trigger/component.js
+++ b/addon/pods/components/rui-dropdown-trigger/component.js
@@ -1,23 +1,29 @@
-import Ember from 'ember';
-import layout from './template';
+import Ember from 'ember'
+import layout from './template'
 
-export default Ember.Component.extend({
+const {
+  Component,
+  computed,
+  Logger
+} = Ember
+
+export default Component.extend({
   layout: layout,
   tagName: 'button',
   classNames: ['dropdown-toggle'],
   classNameBindings: ['computedStyle'],
   attributeBindings: [
-    'type',
-    'data-toggle',
-    'aria-haspopup',
     'aria-expanded',
-    'data-test-id'
+    'aria-haspopup',
+    'data-test-id',
+    'data-toggle',
+    'type'
   ],
 
   //Defaults
-  type: 'button',
-  style: null,
   size: null,
+  style: null,
+  type: 'button',
 
   //Constructors
   classPrefix: 'btn',
@@ -31,23 +37,23 @@ export default Ember.Component.extend({
   'aria-expanded': 'false',
 
   // Computed
-  computedStyle: Ember.computed('style', function(){
+  computedStyle: computed('style', function(){
     // Builds size button class
     // Should not have any btn class by default to allow for custom classing
 
     if (!this.get('style')) {
-      return false;
+      return false
     }
 
-    var styles = this.get('styles');
-    var findStyle = this.get('style');
-    var resolvedStyle = findStyle;
+    const styles = this.get('styles')
+    const findStyle = this.get('style')
+    const resolvedStyle = findStyle
 
     if (styles.indexOf(findStyle) === -1) {
-      resolvedStyle = 'secondary';
-      Ember.Logger.warn('rui-dropdown-trigger: You specified and unsupported \'style\' property so we\'ve defaulted to the secondary style: choose from \'primary secondary success warning danger info link.\'');
+      resolvedStyle = 'secondary'
+      Logger.warn('rui-dropdown-trigger: You specified and unsupported \'style\' property so we\'ve defaulted to the secondary style: choose from \'primary secondary success warning danger info link.\'')
     }
 
-    return 'btn ' + this.get('classPrefix') + '-' + resolvedStyle;
+    return 'btn ' + this.get('classPrefix') + '-' + resolvedStyle
   }),
-});
+})

--- a/app/styles/_rui-base.sass
+++ b/app/styles/_rui-base.sass
@@ -1,10 +1,10 @@
 @import variables
 // Webfonts/External Resources/Etc
 @import fonts/imports
-// bootstrap
-@import bootstrap/bootstrap
 // font-awesome 4.4.0
 @import fonts-icon/icon-font
+// bootstrap
+@import bootstrap/bootstrap
 // Utilities
 @import components/rui-extend
 // Components

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -16,18 +16,11 @@ $rui-text-color-muted:      $gray;
 $rui-text-color-disabled:   $gray-light;
 $rui-text-color-light:      #d4d4d4;
 
-$brand-primary:             #f7931d;
-$brand-success:             #a3cf62;
-$brand-info:                #5b91cc;
-$brand-warning:             #ffc619;
-$brand-danger:              #f26d63;
-
-// Existing variables, see how imports from project work out then merge or delete
-// $brand-primary:             #f7931d;
-// $brand-success:             #5cb85c;
-// $brand-info:                #5bc0de;
-// $brand-warning:             #f0ad4e;
-// $brand-danger:              #d9534f;
+$brand-primary:             #f7931d !default;
+$brand-success:             #a3cf62 !default;
+$brand-info:                #5b91cc !default;
+$brand-warning:             #ffc619 !default;
+$brand-danger:              #f26d63 !default;
 
 $font-family-sans-serif:     "Open Sans", Helvetica, Arial, sans-serif;
 $body-bg:                    $gray-base;
@@ -35,7 +28,7 @@ $body-color:                 $rui-text-color;
 $link-color:                 $brand-primary;
 $font-size-root:             14px;
 $font-size-sm:               .9rem;
-$text-muted:                 $rui-text-color-muted !default;
+$text-muted:                 $rui-text-color-muted;
 
 // This may get fixed at some point when bs4 stablizes
 $card-border-width:          1px;

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -1,29 +1,36 @@
-// Rui custom variables
-$rui-nav-bg:                    #fff;
+$rui-nav-bg:                #fff;
 
-$rui-border-color-dark:         #ccc ;
-$rui-border-color-light:        #f3f1ee;
+$gray-dark:                 #58585b;
+$gray:                      #909091;
+$gray-light:                #cccccc;
+$gray-lighter:              #e8e5e3;
+$gray-lightest:             #efeeed;
+$gray-base:                 #f6f5f3;
 
-$rui-text-color:           #58585b;
-$rui-text-color-muted:     #A7B4B5;
-$rui-text-color-light:     #d4d4d4 ;
+$rui-border-color-dark:     $gray-light;
+$rui-border-color-light:    $gray-lighter;
+$rui-divider-color:         $gray-lightest;
 
-// Bootstrap Variable Overrides
-// TBD: Will want to clean this up when we get a sec
-$gray-dark:                 #373a3c;
-$gray:                      #55595c;
-$gray-light:                #818a91;
-$gray-lighter:              #d4d4d4;
-$gray-lightest:             #fbfaf8;
+$rui-text-color:            $gray-dark;
+$rui-text-color-muted:      $gray;
+$rui-text-color-disabled:   $gray-light;
+$rui-text-color-light:      #d4d4d4;
 
 $brand-primary:             #f7931d;
-$brand-success:             #5cb85c;
-$brand-info:                #5bc0de;
-$brand-warning:             #f0ad4e;
-$brand-danger:              #d9534f;
+$brand-success:             #a3cf62;
+$brand-info:                #5b91cc;
+$brand-warning:             #ffc619;
+$brand-danger:              #f26d63;
+
+// Existing variables, see how imports from project work out then merge or delete
+// $brand-primary:             #f7931d;
+// $brand-success:             #5cb85c;
+// $brand-info:                #5bc0de;
+// $brand-warning:             #f0ad4e;
+// $brand-danger:              #d9534f;
 
 $font-family-sans-serif:     "Open Sans", Helvetica, Arial, sans-serif;
-$body-bg:                    $gray-lightest;
+$body-bg:                    $gray-base;
 $body-color:                 $rui-text-color;
 $link-color:                 $brand-primary;
 $font-size-root:             14px;

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -12,28 +12,24 @@ $rui-border-color-light:    $gray-lighter;
 $rui-divider-color:         $gray-lightest;
 
 $rui-text-color:            $gray-dark;
-$rui-text-color-muted:      $gray;
 $rui-text-color-disabled:   $gray-light;
-$rui-text-color-light:      #d4d4d4;
+$rui-text-color-muted:      $gray;
 
+$brand-danger:              #f26d63 !default;
+$brand-info:                #5b91cc !default;
 $brand-primary:             #f7931d !default;
 $brand-success:             #a3cf62 !default;
-$brand-info:                #5b91cc !default;
 $brand-warning:             #ffc619 !default;
-$brand-danger:              #f26d63 !default;
 
 $font-family-sans-serif:     "Open Sans", Helvetica, Arial, sans-serif;
+
 $body-bg:                    $gray-base;
 $body-color:                 $rui-text-color;
 $link-color:                 $brand-primary;
 $font-size-root:             14px;
-$font-size-sm:               .9rem;
+$font-size-sm:               .92rem;
 $text-muted:                 $rui-text-color-muted;
 
 // This may get fixed at some point when bs4 stablizes
 $card-border-width:          1px;
 $card-border-radius-inner:   .25rem;
-
-//These are defined in bootstrap but will currently not resolve
-$border-radius-base: 3px;
-$font-size-sm: .85rem;

--- a/app/styles/components/_rui-dropdown-trigger.sass
+++ b/app/styles/components/_rui-dropdown-trigger.sass
@@ -4,7 +4,7 @@
   width: auto
   height: auto
   line-height: initial
-  color: $rui-text-color-light
+  color: $rui-text-color-muted
 
 .dropup .dropdown-toggle::after
   @extend .angle-up

--- a/app/styles/components/_rui-dropdowns.sass
+++ b/app/styles/components/_rui-dropdowns.sass
@@ -5,7 +5,7 @@
 
 .dropdown-header
   text-transform: uppercase
-
+  color: $rui-text-color-muted
 
 .dropdown-menu
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175)
@@ -14,7 +14,7 @@
 // Header with full bleed background fill
 .dropdown-header-block
   margin-top: -5px
-  background: $gray-lightest
+  background: $gray-base
   padding: $spacer/2 $spacer
   border-top-left-radius: $border-radius
   border-top-right-radius: $border-radius

--- a/app/styles/components/_rui-forms.sass
+++ b/app/styles/components/_rui-forms.sass
@@ -1,5 +1,10 @@
 .radio,
 .checkbox
   label
-    input:only-child 
+    input:only-child
       position: absolute
+
+.form-control,
+.form-control:active,
+.form-control:focus
+  color: $rui-text-color

--- a/app/styles/fonts-icon/_variables.scss
+++ b/app/styles/fonts-icon/_variables.scss
@@ -685,4 +685,3 @@ $fa-var-yen: "\f157";
 $fa-var-youtube: "\f167";
 $fa-var-youtube-play: "\f16a";
 $fa-var-youtube-square: "\f166";
-


### PR DESCRIPTION
This pr ensures that sass variables can be redefined by consuming apps by adding the '!default' flag.  Simultaneously, it updates grays and other color variables to reflect the changes made to master.

### QA Steps

- Test in concert with [#161](https://invent.focusvision.com/Portland/revelation-frontend-admin/pull/161)