### PR TITLE
Fix deprecation of didInitAttrs

### DIFF
--- a/addon/pods/components/rui-select/component.js
+++ b/addon/pods/components/rui-select/component.js
@@ -24,7 +24,7 @@ export default Ember.Component.extend({
     return { id: this.get('selection') };
   }),
 
-  didInitAttrs() {
+  init() {
     this._super(...arguments);
     if (!this.get('content')) {
       this.set('content', []);


### PR DESCRIPTION
### What does this PR do?

didInitAttrs is deprecated.  This is a simple change to update the depreciated actions.

[Ember Docs on Deprecation](http://emberjs.com/deprecations/v2.x/#toc_ember-component-didinitattrs)

### How should this be tested?

- [x] tests pass

### QA Checklist

- [x] In this repo `npm link`
- [x] In participant app - `npm link ember-cli-revelation-ui`
- [x] Make sure the rui-select works correctly. - On participant, its the timezone selection box.

### Related Issues

- [x] QA Complete

