### PR TITLE
Change computed to update on name change

### DIFF
--- a/addon/pods/components/rui-icon/component.js
+++ b/addon/pods/components/rui-icon/component.js
@@ -11,7 +11,7 @@ export default Ember.Component.extend({
   classPrefix: 'fa',
 
   // Computed
-  nameComputed: Ember.computed('style', function() {
+  nameComputed: Ember.computed('name', function() {
     // Builds the icon class.
     // REVIEW: I wonder if there's an "easy" way to have this check if the icon
     //   name exists that doesn't rely on manually updating an array. It would

--- a/tests/unit/components/rui-avatar-test.js
+++ b/tests/unit/components/rui-avatar-test.js
@@ -14,8 +14,8 @@ test('it renders', function(assert) {
 
   // NOTE: `tagName` comparison is case-sensitive
   assert.equal(
-    this.$().get(0).tagName.toLowerCase(), 'img',
-    'it renders the component with an `img` tag'
+    this.$().get(0).tagName.toLowerCase(), 'span',
+    'it renders the component with an `span` tag'
   );
   assert.ok(
     this.$().hasClass('rui-avatar'),
@@ -29,7 +29,7 @@ test('it displays the correct image', function(assert) {
   this.render();
 
   assert.equal(
-    this.$().attr('src'), 'http://placehold.it/32?text=%20',
+    this.$().text().trim(), '',
     'it should fallback to a placeholder when a `src` is not supplied'
   );
 
@@ -37,7 +37,7 @@ test('it displays the correct image', function(assert) {
     component.set('src', '');
   });
   assert.equal(
-    this.$().attr('src'), 'http://placehold.it/32?text=%20',
+    this.$().text().trim(), '',
     'it should fallback to a placeholder when `src` is empty'
   );
 
@@ -45,7 +45,7 @@ test('it displays the correct image', function(assert) {
     component.set('src', 'http://placehold.it/32x32');
   });
   assert.equal(
-    this.$().attr('src'), 'http://placehold.it/32x32',
+    this.$().children().attr('src'), 'http://placehold.it/32x32',
     'it should display the provided `src` image'
   );
 });

--- a/tests/unit/components/rui-icon-test.js
+++ b/tests/unit/components/rui-icon-test.js
@@ -21,3 +21,23 @@ test('it renders', function(assert) {
     'it renders with the base class `fa`'
   );
 });
+
+test('it updates when settings change', function(assert) {
+  assert.expect(2)
+  var component = this.subject()
+  component.set('name', 'times')
+
+  assert.equal(
+    component.get('nameComputed'),
+    'fa-times',
+    'name is times on initial render'
+  )
+
+  component.set('name', 'check')
+
+  assert.equal(
+    component.get('nameComputed'),
+    'fa-check',
+    'name is updated to check when computed'
+  )
+})


### PR DESCRIPTION
### What does this PR do?

Makes it so that Rui-icon updates when name changes. It also fixes some broken tests from previous changes.

### How should this be tested?

- [x] Tests pass

### QA Checklist

- [x] In this app, run `npm link`
- [x] In participant app, checkout branch `feature/km/new-routes` - if that is merged into master, then PERFECT!
- [x] run `npm link ember-cli-revelation-ui`
- [x] fire up the participant app (`ember s`)
- [x] Login as a participant that is a part of study
- [ ] Go to `http://localhost:3000/cli/ep/`
- [x] Navigate to Feed (putting it in mobile view will help with display
- [x] Click on the hearts to verify that the icon fills or empties on click

### Related Issues

Closes #111 

- [x] QA Complete

