### PR TITLE
Configure dummy app to use pod structure

### DIFF
--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -3,6 +3,8 @@
 module.exports = function(environment) {
   var ENV = {
     modulePrefix: 'dummy',
+    podModulePrefix: 'dummy/pods',
+
     environment: environment,
     baseURL: '/',
     locationType: 'auto',


### PR DESCRIPTION
### What does this PR do?

It fixes an error with the dummy app not setting up pod structure correctly.

### QA Checklist

- [x] Load app with `ember s`
- [x] go to `http://localhost:4210`
- [x] Click on styles - make sure page loads
- [x] Click on components - make sure page loads

### Impacted Areas

Dummy App

### Related Issues

Closes #113 

- [x] QA Complete

