### PR TITLE
Adds optional link for error template.

### DIFF
--- a/addon/pods/components/rui-error-template/component.js
+++ b/addon/pods/components/rui-error-template/component.js
@@ -1,15 +1,13 @@
 import Ember from 'ember'
 import layout from './template'
 
+const { computed } = Ember
+
 export default Ember.Component.extend({
   classNames: ['rui-error-template'],
   layout,
 
-  externalLink: Ember.computed(function() {
-    let link = this.get('link')
-
-    return link.indexOf('http') >= 0 ? true : false
-  }),
+  externalLink: computed.match('link',  /^(http|https)/),
 
   actions: {
     back(event){

--- a/addon/pods/components/rui-error-template/component.js
+++ b/addon/pods/components/rui-error-template/component.js
@@ -1,9 +1,9 @@
 import Ember from 'ember'
 import layout from './template'
 
-const { computed } = Ember
+const { Component, computed } = Ember
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNames: ['rui-error-template'],
   layout,
 

--- a/addon/pods/components/rui-error-template/component.js
+++ b/addon/pods/components/rui-error-template/component.js
@@ -5,6 +5,12 @@ export default Ember.Component.extend({
   classNames: ['rui-error-template'],
   layout,
 
+  externalLink: Ember.computed(function() {
+    let link = this.get('link')
+
+    return link.indexOf('http') >= 0 ? true : false
+  }),
+
   actions: {
     back(event){
       event.preventDefault()

--- a/addon/pods/components/rui-error-template/template.hbs
+++ b/addon/pods/components/rui-error-template/template.hbs
@@ -14,5 +14,14 @@
     <div class="rui-error-template-tagline">
       {{tagline}}
     </div>
+    {{#if link}}
+      <div class='rui-error-button'>
+        <a href={{link}}>
+          {{#rui-button size='lg'}}
+            {{link-message}}
+          {{/rui-button}}
+        </a>
+      </div>
+    {{/if}}
   </div>
 </div>

--- a/addon/pods/components/rui-error-template/template.hbs
+++ b/addon/pods/components/rui-error-template/template.hbs
@@ -15,9 +15,15 @@
       {{tagline}}
     </div>
     {{#if link}}
-      <a class='btn btn-secondary btn-lg rui-error-button' href={{link}}>
-        {{link-message}}
-      </a>
+      {{#if externalLink}}
+        <a class='btn btn-secondary btn-lg rui-error-button' href={{link}}>
+          {{link-message}}
+        </a>
+      {{else}}
+        {{#link-to link class='btn btn-secondary btn-lg rui-error-button'}}
+          {{link-message}}
+        {{/link-to}}
+      {{/if}}
     {{/if}}
   </div>
 </div>

--- a/addon/pods/components/rui-error-template/template.hbs
+++ b/addon/pods/components/rui-error-template/template.hbs
@@ -15,13 +15,9 @@
       {{tagline}}
     </div>
     {{#if link}}
-      <div class='rui-error-button'>
-        <a href={{link}}>
-          {{#rui-button size='lg'}}
-            {{link-message}}
-          {{/rui-button}}
-        </a>
-      </div>
+      <a class='btn btn-secondary btn-lg rui-error-button' href={{link}}>
+        {{link-message}}
+      </a>
     {{/if}}
   </div>
 </div>

--- a/app/styles/components/_rui-error-template.sass
+++ b/app/styles/components/_rui-error-template.sass
@@ -18,6 +18,9 @@
 .rui-error-template-tagline
   font-size: $font-size-lg
 
+.rui-error-button
+  padding: 18px
+
 .rui-header-nav-group
   display: flex
   height: $rui-header-height

--- a/app/styles/components/_rui-error-template.sass
+++ b/app/styles/components/_rui-error-template.sass
@@ -19,7 +19,7 @@
   font-size: $font-size-lg
 
 .rui-error-button
-  padding: 18px
+  margin-top: 18px
 
 .rui-header-nav-group
   display: flex


### PR DESCRIPTION
### What does this PR do?
- Adds an optional link and link message arguments to the error template.
- If utilized, the standard rev-ui button will be placed into the template. The button will act as a link to whatever was passed to the component as the `link` argument.
- The button will be titled with whatever is passed in as the link-message argument.

Screenshot example:

![screen shot 2016-07-15 at 1 28 45 pm](https://cloud.githubusercontent.com/assets/5505212/16890527/5c4b7534-4aa4-11e6-9399-bff50df637e3.png)

### QA Checklist
- From the rev-ui repo, run: `ember s`
- In the browser, navigate to localhost:4210
- [x] The Dummy App loads properly
- Navigate to localhost:4210/tests
- All tests pass

### Impacted Areas
  - The Rev-UI app
### Questions?

### Related Issues

RFC <#RFC>



- [x] QA Complete

