### PR TITLE
Remove data-test-id from components, add data-test to component base

### DIFF
--- a/addon/pods/components/rui-button/component.js
+++ b/addon/pods/components/rui-button/component.js
@@ -6,7 +6,7 @@ export default Ember.Component.extend({
   tagName: 'button',
   classNames: ['btn'],
   classNameBindings: ['styleComputed', 'sizeComputed', 'blockComputed', 'isLoading'],
-  attributeBindings: ['disabled', 'data-test-id'],
+  attributeBindings: ['disabled'],
   disabled: false,
   isLoading: false,
   action: Ember.K,

--- a/addon/pods/components/rui-dropdown-menu/component.js
+++ b/addon/pods/components/rui-dropdown-menu/component.js
@@ -6,10 +6,7 @@ export default Ember.Component.extend({
   tagName: 'div',
   classNames: 'dropdown-menu',
   classNameBindings: 'alignComputed',
-  attributeBindings: [
-    'aria-labelledby',
-    'data-test-id'
-  ],
+  attributeBindings: ['aria-labelledby'],
 
   // Defaults
   prefixClass: 'dropdown-menu-',

--- a/addon/pods/components/rui-dropdown-trigger/component.js
+++ b/addon/pods/components/rui-dropdown-trigger/component.js
@@ -15,7 +15,6 @@ export default Component.extend({
   attributeBindings: [
     'aria-expanded',
     'aria-haspopup',
-    'data-test-id',
     'data-toggle',
     'type'
   ],

--- a/addon/pods/components/rui-validatable-input/component.js
+++ b/addon/pods/components/rui-validatable-input/component.js
@@ -8,7 +8,6 @@ const {
 } = Ember
 
 export default Component.extend({
-  attributeBindings: ['data-test-id'],
   classNameBindings: ['showErrorClass:has-error', 'isValid:has-success'],
   classNames: ['rui-validatable-input'],
   layout,

--- a/addon/pods/components/rui-validatable-textarea/component.js
+++ b/addon/pods/components/rui-validatable-textarea/component.js
@@ -8,7 +8,6 @@ const {
 } = Ember
 
 export default Component.extend({
-  attributeBindings: ['data-test-id'],
   classNameBindings: ['showErrorClass:has-error', 'isValid:has-success'],
   classNames: ['rui-validatable-textarea'],
   layout,

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -13,6 +13,17 @@ App = Ember.Application.extend({
   Resolver: Resolver
 });
 
+Ember.Component.reopen({
+  attributeBindings: ['dataTest:data-test'],
+  dataTest: Ember.computed(function() {
+    const suffix = this.get('dataTestSuffix')
+    let baseId = (this._debugContainerKey || '')
+      .replace(/.*component:/g, '')
+      .replace(/\//g, '-')
+    return suffix ? `${baseId}-${suffix}` : baseId
+  })
+})
+
 loadInitializers(App, config.modulePrefix);
 
 export default App;


### PR DESCRIPTION
### What does this PR do?

Removes data-test-id from each individual components to ensure it does not override consuming apps data-test-id implementation.

Reopens component in test suite and applies globally within addon for testing.

### How should this be tested?

Dependent Branch Participant
https://invent.focusvision.com/Portland/revelation-frontend-participant/pull/206

Dependent Branch Admin
https://invent.focusvision.com/Portland/revelation-frontend-admin/pull/197

- [ ] from addon`npm link`
- [ ] from participant app `npm link ember-cli-revelation-ui`
- [ ] ensure tests pass `localhost:4202/tests`
- [ ] from admin app `npm link ember-cli-revelation-ui`
- [ ] ensure tests pass `localhost:4201/tests`

### QA Checklist

### Impacted Areas

Testing

### Questions?

### Related Issues

Dependent: https://invent.focusvision.com/Portland/revelation-frontend-admin/pull/197
Issue: https://invent.focusvision.com/Portland/revelation-frontend-admin/issues/198

- [ ] QA Complete
