### PR TITLE
#228 - [Participant App] Extend addons validateable input to support async validation (RUI Addon)

### DIFF
--- a/addon/pods/components/rui-validatable-input/component.js
+++ b/addon/pods/components/rui-validatable-input/component.js
@@ -59,8 +59,7 @@ export default Component.extend({
   // the `_didChange` attr would report it had not
 
   _validatePresenceWithEmptyDefault: computed('value', function() {
-    const validationOptions = Object.keys(
-      this.get(`model.validations.attrs.${this.get('valuePath')}.options`))
+    const validationOptions = Object.keys(this.get('validation.options'))
 
     return (validationOptions.indexOf('presence') !== -1) &&
       (this.get('value') === undefined) ||

--- a/addon/pods/components/rui-validatable-input/component.js
+++ b/addon/pods/components/rui-validatable-input/component.js
@@ -50,14 +50,16 @@ export default Component.extend({
 
   isInvalid: computed('_isInvalid', '_didValidate', function() {
     if (this.get('async')) {
-      return this.get('_isInvalid') && this.get('_didValidate')
+      return this.get('_isInvalid') &&
+      this.get('_didValidate')
     }
     return this.get('_isInvalid')
   }),
 
   isValid: computed('_isValid', '_didValidate', function() {
     if (this.get('async')) {
-      return this.get('_isValid') && this.get('_didValidate')
+      return this.get('_isValid') &&
+      this.get('_didValidate')
     }
     return this.get('_isValid')
   }),

--- a/addon/pods/components/rui-validatable-input/component.js
+++ b/addon/pods/components/rui-validatable-input/component.js
@@ -58,7 +58,7 @@ export default Component.extend({
   // (the case with new records) we can still validate even though
   // the `_didChange` attr would report it had not
 
-  _validatePresenceWithEmptyDefault: computed('value', function() {
+  _forcePresenceValidation: computed('value', function() {
     const validationOptions = Object.keys(this.get('validation.options'))
 
     return (validationOptions.indexOf('presence') !== -1) &&
@@ -74,7 +74,7 @@ export default Component.extend({
     'value',
     'model.hasDirtyAttributes',
     function() {
-      if (this.get('_validatePresenceWithEmptyDefault')) { return true }
+      if (this.get('_forcePresenceValidation')) { return true }
 
       const attrsChanged = this.get('model') ?
         this.get('model').changedAttributes() : {}

--- a/addon/pods/components/rui-validatable-input/component.js
+++ b/addon/pods/components/rui-validatable-input/component.js
@@ -8,7 +8,10 @@ const {
 } = Ember
 
 export default Component.extend({
-  classNameBindings: ['isInvalid:has-error', 'isValid:has-success'],
+  classNameBindings: [
+    'isInvalid:has-error',
+    'isValid:has-success'
+  ],
   classNames: ['rui-validatable-input'],
   layout,
 
@@ -30,10 +33,16 @@ export default Component.extend({
   init() {
     this._super(...arguments)
     const valuePath = this.get('valuePath')
-    defineProperty(this,
+    defineProperty(
+      this,
       'validation',
-      computed.oneWay(`model.validations.attrs.${valuePath}`))
-    defineProperty(this, 'value', computed.alias(`model.${valuePath}`))
+      computed.oneWay(`model.validations.attrs.${valuePath}`)
+    )
+    defineProperty(
+      this,
+      'value',
+      computed.alias(`model.${valuePath}`)
+    )
   },
 
   // Validation binding attributes with check for async settings

--- a/addon/pods/components/rui-validatable-input/component.js
+++ b/addon/pods/components/rui-validatable-input/component.js
@@ -33,7 +33,6 @@ export default Component.extend({
 
   // Compute the property to give priority to
   // `isSaving` property if found on controller
-  // passed in via the
 
   isSavingComputed: computed('model.isSaving', 'targetObject.isSaving', function() {
     const isSavingFromController = this.get('targetObject.isSaving')
@@ -64,15 +63,13 @@ export default Component.extend({
   _isInvalid: computed.and('validation.isInvalid', 'validatable'),
   _isValid: computed.and('validation.isValid', 'validatable'),
 
-  // Checks property `targetObject.didValidate`
-  // Toggled true when `model.validate()` is called
+  // Checks property `didValidate` on controller
   // Used to only show validation if `async` is true
 
   didValidate: computed.oneWay('targetObject.didValidate'),
 
   // Validation binding attributes with check for async settings
   // if async is true, don't display either until `didValidate`
-  // is toggled manually by valling `model.validate()` before `save()`
 
   isInvalid: computed('_isInvalid', 'didValidate', function() {
     if (this.get('async')) {

--- a/addon/pods/components/rui-validatable-input/component.js
+++ b/addon/pods/components/rui-validatable-input/component.js
@@ -42,23 +42,11 @@ export default Component.extend({
   // the validator includes presence and
   // the value is undefined or empty
 
-  didChange: computed('value', 'model.hasDirtyAttributes', 'isSaving', function() {
+  didChange: computed('value', 'model.hasDirtyAttributes', 'model.isSaving', function() {
     if (this.get('validatePresenceWithEmptyDefault')) { return true }
 
     const attrsChanged = this.get('model') ? this.get('model').changedAttributes() : {}
     return this.get('valuePath') in attrsChanged
-  }),
-
-  // Compute the property to give priority to
-  // `isSaving` property if found on controller
-
-  isSavingComputed: computed('model.isSaving', 'targetObject.isSaving', function() {
-    const isSavingFromController = this.get('targetObject.isSaving')
-    if ((typeof isSavingFromController !== 'undefined') &&
-      (isSavingFromController !== null)) {
-        return isSavingFromController
-      }
-    return this.get('model.isSaving')
   }),
 
   // Checks for in processing statuses
@@ -68,11 +56,11 @@ export default Component.extend({
   validatable: computed(
     'didChange',
     'validation.isValidating',
-    'isSavingComputed',
+    'model.isSaving',
     function() {
       return this.get('didChange') &&
       !this.get('validation.isValidating') &&
-      !this.get('isSavingComputed')
+      !this.get('model.isSaving')
     }
   ),
 

--- a/addon/pods/components/rui-validatable-input/component.js
+++ b/addon/pods/components/rui-validatable-input/component.js
@@ -20,7 +20,9 @@ export default Component.extend({
   init() {
     this._super(...arguments)
     const valuePath = this.get('valuePath')
-    defineProperty(this, 'validation', computed.oneWay(`model.validations.attrs.${valuePath}`))
+    defineProperty(this,
+      'validation',
+      computed.oneWay(`model.validations.attrs.${valuePath}`))
     defineProperty(this, 'value', computed.alias(`model.${valuePath}`))
   },
 
@@ -42,12 +44,18 @@ export default Component.extend({
   // the validator includes presence and
   // the value is undefined or empty
 
-  didChange: computed('value', 'model.hasDirtyAttributes', 'model.isSaving', function() {
-    if (this.get('validatePresenceWithEmptyDefault')) { return true }
+  didChange: computed(
+    'value',
+    'model.hasDirtyAttributes',
+    'model.isSaving',
+    function() {
+      if (this.get('validatePresenceWithEmptyDefault')) { return true }
 
-    const attrsChanged = this.get('model') ? this.get('model').changedAttributes() : {}
-    return this.get('valuePath') in attrsChanged
-  }),
+      const attrsChanged = this.get('model') ?
+        this.get('model').changedAttributes() : {}
+      return this.get('valuePath') in attrsChanged
+    }
+  ),
 
   // Checks for in processing statuses
   // Ensures validations don't show when:

--- a/addon/pods/components/rui-validatable-input/component.js
+++ b/addon/pods/components/rui-validatable-input/component.js
@@ -96,5 +96,5 @@ export default Component.extend({
   // Checks property `_didValidate` on controller
   // Used to only show validation if `async` is true
 
-  _didValidate: computed.oneWay('targetObject._didValidate')
+  _didValidate: computed.oneWay('targetObject.didValidate')
 })

--- a/addon/pods/components/rui-validatable-input/component.js
+++ b/addon/pods/components/rui-validatable-input/component.js
@@ -43,9 +43,7 @@ export default Component.extend({
   // the value is undefined or empty
 
   didChange: computed('value', 'model.hasDirtyAttributes', 'isSaving', function() {
-    if (this.get('validatePresenceWithEmptyDefault')) {
-        return true
-    }
+    if (this.get('validatePresenceWithEmptyDefault')) { return true }
 
     const attrsChanged = this.get('model') ? this.get('model').changedAttributes() : {}
     return this.get('valuePath') in attrsChanged

--- a/addon/pods/components/rui-validatable-input/component.js
+++ b/addon/pods/components/rui-validatable-input/component.js
@@ -51,7 +51,7 @@ export default Component.extend({
   isInvalid: computed('_isInvalid', '_didValidate', function() {
     if (this.get('async')) {
       return this.get('_isInvalid') &&
-      this.get('_didValidate')
+        this.get('_didValidate')
     }
     return this.get('_isInvalid')
   }),
@@ -59,7 +59,7 @@ export default Component.extend({
   isValid: computed('_isValid', '_didValidate', function() {
     if (this.get('async')) {
       return this.get('_isValid') &&
-      this.get('_didValidate')
+        this.get('_didValidate')
     }
     return this.get('_isValid')
   }),

--- a/addon/pods/components/rui-validatable-input/component.js
+++ b/addon/pods/components/rui-validatable-input/component.js
@@ -9,13 +9,23 @@ const {
 
 export default Component.extend({
   classNameBindings: ['isInvalid:has-error', 'isValid:has-success'],
-  classNames: ['rui-_validatable-input'],
+  classNames: ['rui-validatable-input'],
   layout,
-  model: null,
-  placeholder: '',
+
+  // Default Attrs
+
   type: 'text',
-  valuePath: '',
   async: false,
+
+  // Passed Attrs
+
+  // valuePath: string
+  // model: object
+
+  // Init Attrs
+
+  // value: @alias model.valuePath
+  // validation: @oneway model.validations.attrs.valuePath
 
   init() {
     this._super(...arguments)

--- a/addon/pods/components/rui-validatable-input/component.js
+++ b/addon/pods/components/rui-validatable-input/component.js
@@ -31,6 +31,19 @@ export default Component.extend({
     return this.get('valuePath') in attrsChanged
   }),
 
+  // Compute the property to give priority to
+  // `isSaving` property if found on controller
+  // passed in via the
+
+  isSavingComputed: computed('model.isSaving', 'targetObject.isSaving', function() {
+    const isSavingFromController = this.get('targetObject.isSaving')
+    if ((typeof isSavingFromController !== 'undefined') &&
+      (isSavingFromController !== null)) {
+        return isSavingFromController
+      }
+    return this.get('model.isSaving')
+  }),
+
   // Checks for in processing statuses
   // Ensures validations don't show when:
   // input is clean, is validating, model is saving
@@ -38,11 +51,11 @@ export default Component.extend({
   validatable: computed(
     'didChange',
     'validation.isValidating',
-    'model.isSaving',
+    'isSavingComputed',
     function() {
       return this.get('didChange') &&
       !this.get('validation.isValidating') &&
-      !this.get('model.isSaving')
+      !this.get('isSavingComputed')
     }
   ),
 
@@ -51,7 +64,7 @@ export default Component.extend({
   _isInvalid: computed.and('validation.isInvalid', 'validatable'),
   _isValid: computed.and('validation.isValid', 'validatable'),
 
-  // Checks property `target.didValidate`
+  // Checks property `targetObject.didValidate`
   // Toggled true when `model.validate()` is called
   // Used to only show validation if `async` is true
 

--- a/addon/pods/components/rui-validatable-input/template.hbs
+++ b/addon/pods/components/rui-validatable-input/template.hbs
@@ -11,9 +11,8 @@ name=valuePath}}
   </p>
 {{/if}}
 
-{{#if showMessage}}
+{{#if isInvalid}}
   <p class='input-error'>
     {{v-get model valuePath 'message'}}
   </p>
 {{/if}}
-


### PR DESCRIPTION
### What does this PR do?

This PR extends the validateable input to include an async flag.  If false it will not display error states until the `didValidate` flag has been toggled.  This property must be managed on the controller level.

Additionally it cleans up some of the logic which was making some incorrect assumptions and was hard to reason about.

### How should this be tested?

This will need to be tested on admin and the new participant app.

**Set Up UI**
- Pull latest and `npm link` (make sure you are using `node 4.4.4`)

**Set up discuss**
- Pull `revelation-frontend-discuss` 
- `nvm use 4.4.4`
- `npm link ember-cli-revelation-ui  && npm install`
- `ember s`
- Navigate to `localhost:3000/cli/ea/:project_id/setup/settings/digest/customize

**Set up participant**
- pull `revelation-frontend-participant`
- `nvm use 4.4.4`
- `npm link ember-cli-revelation-ui  && npm install`
- `ember s --environment mobileDev`
- Navigate to `localhost:4202/#/login`

### QA Checklist

**Digest (synchronous validation)**

- [x] Digest inputs show error when empty
- [x] Show valid when not empty and changed
- [x] Validation clears after save

**Participant (asynchronousvalidation)**

- [x] Login fields do not display validation when changed
- [x] When login button clicked, validation shows
- [x] Once validation is triggered, validators will validate asyncronously

### Impacted Areas

- Discuss (Just the settings form and only plain text input fields)
- Participant Login

### Related Issues

Closes #228
https://invent.focusvision.com/Portland/revelation-frontend-participant/issues/228

- [x] QA Complete
